### PR TITLE
[Feat] User Entity 및 값 객체 설계

### DIFF
--- a/user-service/build.gradle
+++ b/user-service/build.gradle
@@ -36,6 +36,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 
     // database
     runtimeOnly 'com.mysql:mysql-connector-j'

--- a/user-service/src/main/java/shop/genieus/user/application/out/support/encoder/PasswordEncryptionPort.java
+++ b/user-service/src/main/java/shop/genieus/user/application/out/support/encoder/PasswordEncryptionPort.java
@@ -1,0 +1,5 @@
+package shop.genieus.user.application.out.support.encoder;
+
+import shop.genieus.user.domain.model.service.PasswordEncryptionService;
+
+public interface PasswordEncryptionPort extends PasswordEncryptionService {}

--- a/user-service/src/main/java/shop/genieus/user/domain/model/entity/BaseEntity.java
+++ b/user-service/src/main/java/shop/genieus/user/domain/model/entity/BaseEntity.java
@@ -1,0 +1,55 @@
+package shop.genieus.user.domain.model.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import org.hibernate.annotations.Comment;
+import org.hibernate.annotations.CurrentTimestamp;
+import org.springframework.data.annotation.CreatedBy;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedBy;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseEntity {
+
+  @CreatedDate
+  @Column(name = "created_at", nullable = false, updatable = false)
+  @CurrentTimestamp
+  @Comment("생성 일시")
+  private LocalDateTime createdAt;
+
+  @CreatedBy
+  @Column(name = "created_by", nullable = false, updatable = false)
+  @Comment("생성자")
+  private Long createdBy;
+
+  @LastModifiedDate
+  @Column(name = "updated_at", insertable = false)
+  @CurrentTimestamp
+  @Comment("수정 일시")
+  private LocalDateTime updatedAt;
+
+  @LastModifiedBy
+  @Column(name = "updated_by", insertable = false)
+  @Comment("수정자")
+  private Long updatedBy;
+
+  @Column(name = "deleted_at")
+  @Comment("삭제 일시")
+  private LocalDateTime deletedAt;
+
+  @Column(name = "deleted_by")
+  @Comment("삭제자")
+  private Long deletedBy;
+
+  public void delete(Long id) {
+    this.deletedAt = LocalDateTime.now();
+    this.deletedBy = id;
+  }
+}

--- a/user-service/src/main/java/shop/genieus/user/domain/model/entity/User.java
+++ b/user-service/src/main/java/shop/genieus/user/domain/model/entity/User.java
@@ -1,0 +1,99 @@
+package shop.genieus.user.domain.model.entity;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import jakarta.persistence.AttributeOverride;
+import jakarta.persistence.AttributeOverrides;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Comment;
+import shop.genieus.user.domain.model.service.PasswordEncryptionService;
+import shop.genieus.user.domain.model.vo.Address;
+import shop.genieus.user.domain.model.vo.BirthInfo;
+import shop.genieus.user.domain.model.vo.Email;
+import shop.genieus.user.domain.model.vo.Name;
+import shop.genieus.user.domain.model.vo.Password;
+import shop.genieus.user.domain.model.vo.PhoneNumber;
+import shop.genieus.user.domain.model.vo.Role;
+import shop.genieus.user.domain.model.vo.RoleType;
+
+@Entity
+@Getter
+@Builder
+@Comment("사용자 테이블")
+@Table(name = "m_user")
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class User extends BaseEntity {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "user_id")
+  private Long id;
+
+  @Embedded
+  @Comment("사용자 로그인 아이디(이메일)")
+  private Email email;
+
+  @Embedded
+  @Comment("사용자 이름")
+  private Name name;
+
+  @Embedded
+  @Comment("비밀번호 정보")
+  @JsonIgnore
+  private Password password;
+
+  @Embedded
+  @Comment("사용자 권한")
+  private Role role;
+
+  @Embedded
+  @AttributeOverrides({
+    @AttributeOverride(name = "birthdate", column = @Column(name = "birthdate")),
+    @AttributeOverride(name = "gender", column = @Column(name = "gender"))
+  })
+  @Comment("생년월일 및 성별 정보")
+  private BirthInfo birthInfo;
+
+  @Embedded
+  @Comment("사용자 휴대폰 번호")
+  private PhoneNumber phoneNumber;
+
+  @Embedded
+  @Comment("사용자 기본 배송지 주소")
+  private Address address;
+
+  @Builder.Default
+  @Comment("활성화 상태")
+  @Column(name = "is_active")
+  private boolean isActive = true;
+
+  public static User create(
+      String email,
+      String name,
+      String password,
+      PasswordEncryptionService passwordEncryptionService,
+      RoleType roleType,
+      String residentIdFront,
+      String phoneNumber,
+      String address) {
+    return User.builder()
+        .email(Email.of(email))
+        .name(Name.of(name))
+        .password(Password.of(password, passwordEncryptionService))
+        .role(Role.of(roleType))
+        .birthInfo(BirthInfo.fromResidentIdFront(residentIdFront))
+        .phoneNumber(PhoneNumber.of(phoneNumber))
+        .address(address != null ? Address.of(address) : null)
+        .build();
+  }
+}

--- a/user-service/src/main/java/shop/genieus/user/domain/model/service/PasswordEncryptionService.java
+++ b/user-service/src/main/java/shop/genieus/user/domain/model/service/PasswordEncryptionService.java
@@ -1,0 +1,7 @@
+package shop.genieus.user.domain.model.service;
+
+public interface PasswordEncryptionService {
+  String encode(String rawPassword);
+
+  boolean matches(String rawPassword, String encodedPassword);
+}

--- a/user-service/src/main/java/shop/genieus/user/domain/model/vo/Address.java
+++ b/user-service/src/main/java/shop/genieus/user/domain/model/vo/Address.java
@@ -1,0 +1,38 @@
+package shop.genieus.user.domain.model.vo;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Address {
+  private static final int MAX_LENGTH = 255;
+
+  @Column(name = "address", length = MAX_LENGTH)
+  private String value;
+
+  private Address(String value) {
+    if (value != null) {
+      validateAddress(value);
+    }
+    this.value = value;
+  }
+
+  public static Address of(String value) {
+    return new Address(value);
+  }
+
+  private void validateAddress(String address) {
+    if (address.isBlank()) {
+      throw new IllegalArgumentException("주소가 비어있습니다");
+    }
+
+    if (address.length() > MAX_LENGTH) {
+      throw new IllegalArgumentException("주소는 255자를 초과할 수 없습니다");
+    }
+  }
+}

--- a/user-service/src/main/java/shop/genieus/user/domain/model/vo/BirthInfo.java
+++ b/user-service/src/main/java/shop/genieus/user/domain/model/vo/BirthInfo.java
@@ -1,0 +1,104 @@
+package shop.genieus.user.domain.model.vo;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import java.time.DateTimeException;
+import java.time.LocalDate;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class BirthInfo {
+  private static final int RESIDENT_ID_FRONT_LENGTH = 7;
+  private static final int DATE_PART_LENGTH = 6;
+
+  @Column(name = "birthdate", nullable = false)
+  private LocalDate birthdate;
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "gender", length = 10, nullable = false)
+  private Gender gender;
+
+  private BirthInfo(String datePart, char identifierDigit) {
+    validate(datePart, identifierDigit);
+    this.birthdate = parseToDate(datePart, identifierDigit);
+    this.gender = KoreanResidentIdPolicy.parseGender(identifierDigit);
+  }
+
+  public static BirthInfo fromResidentIdFront(String frontPart) {
+    if (frontPart == null || frontPart.length() != RESIDENT_ID_FRONT_LENGTH) {
+      throw new IllegalArgumentException(
+          "주민등록번호 앞 " + RESIDENT_ID_FRONT_LENGTH + "자리는 YYMMDD+성별식별코드 형식이어야 합니다");
+    }
+
+    String datePart = frontPart.substring(0, DATE_PART_LENGTH);
+    char identifierDigit = frontPart.charAt(DATE_PART_LENGTH);
+
+    return new BirthInfo(datePart, identifierDigit);
+  }
+
+  private void validate(String datePart, char identifierDigit) {
+    if (!datePart.matches("\\d{" + DATE_PART_LENGTH + "}")) {
+      throw new IllegalArgumentException("생년월일은 " + DATE_PART_LENGTH + "자리 숫자여야 합니다");
+    }
+
+    if (!KoreanResidentIdPolicy.isValidIdentifierDigit(identifierDigit)) {
+      throw new IllegalArgumentException("주민등록번호 식별자 자리는 1~4 중 하나여야 합니다");
+    }
+
+    try {
+      LocalDate birth = parseToDate(datePart, identifierDigit);
+
+      if (birth.isAfter(LocalDate.now())) {
+        throw new IllegalArgumentException("생년월일은 현재 날짜보다 이전이어야 합니다");
+      }
+
+      if (birth.isAfter(LocalDate.now().minusYears(14))) {
+        throw new IllegalArgumentException("만 14세 이상만 등록할 수 있습니다");
+      }
+
+    } catch (DateTimeException e) {
+      throw new IllegalArgumentException("유효하지 않은 날짜입니다: " + e.getMessage());
+    }
+  }
+
+  private LocalDate parseToDate(String datePart, char identifierDigit) {
+    boolean is1900s = KoreanResidentIdPolicy.isBornIn1900s(identifierDigit);
+    int year = Integer.parseInt(datePart.substring(0, 2));
+    int fullYear = is1900s ? 1900 + year : 2000 + year;
+    int month = Integer.parseInt(datePart.substring(2, 4));
+    int day = Integer.parseInt(datePart.substring(4, 6));
+    return LocalDate.of(fullYear, month, day);
+  }
+
+  private static class KoreanResidentIdPolicy {
+
+    public static Gender parseGender(char identifierDigit) {
+      return switch (identifierDigit) {
+        case '1', '3' -> Gender.MALE;
+        case '2', '4' -> Gender.FEMALE;
+        default -> throw new IllegalArgumentException("알 수 없는 주민등록번호 식별자입니다: " + identifierDigit);
+      };
+    }
+
+    public static boolean isBornIn1900s(char identifierDigit) {
+      return identifierDigit == '1' || identifierDigit == '2';
+    }
+
+    public static char toIdentifierDigit(Gender gender, boolean is1900s) {
+      return switch (gender) {
+        case MALE -> is1900s ? '1' : '3';
+        case FEMALE -> is1900s ? '2' : '4';
+      };
+    }
+
+    public static boolean isValidIdentifierDigit(char digit) {
+      return digit == '1' || digit == '2' || digit == '3' || digit == '4';
+    }
+  }
+}

--- a/user-service/src/main/java/shop/genieus/user/domain/model/vo/Email.java
+++ b/user-service/src/main/java/shop/genieus/user/domain/model/vo/Email.java
@@ -1,0 +1,43 @@
+package shop.genieus.user.domain.model.vo;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Email {
+  private static final int MAX_LENGTH = 20;
+  private static final String EMAIL_REGEX =
+      "^[a-zA-Z0-9_+&*-]+(?:\\.[a-zA-Z0-9_+&*-]+)*@(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,7}$";
+
+  @Column(name = "email", length = MAX_LENGTH, unique = true, nullable = false)
+  private String value;
+
+  private Email(String value) {
+    validate(value);
+    this.value = value;
+  }
+
+  public static Email of(String value) {
+    return new Email(value);
+  }
+
+  private void validate(String value) {
+    if (value == null || value.isBlank()) {
+      throw new IllegalArgumentException("이메일은 필수 입력값입니다");
+    }
+
+    if (!value.matches(EMAIL_REGEX)) {
+      throw new IllegalArgumentException(
+          "이메일 형식이 올바르지 않습니다. 이메일은 영문자, 숫자, 특수문자(_+&*-)로 구성된 아이디와 도메인으로 구성되어야 합니다.");
+    }
+
+    if (value.length() > 20) {
+      throw new IllegalArgumentException("이메일은 " + MAX_LENGTH + "자를 초과할 수 없습니다");
+    }
+  }
+}

--- a/user-service/src/main/java/shop/genieus/user/domain/model/vo/Gender.java
+++ b/user-service/src/main/java/shop/genieus/user/domain/model/vo/Gender.java
@@ -1,0 +1,14 @@
+package shop.genieus.user.domain.model.vo;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum Gender {
+  MALE("남성"),
+  FEMALE("여성");
+
+  private final String koreanName;
+  private final String englishName = this.name();
+}

--- a/user-service/src/main/java/shop/genieus/user/domain/model/vo/Name.java
+++ b/user-service/src/main/java/shop/genieus/user/domain/model/vo/Name.java
@@ -1,0 +1,36 @@
+package shop.genieus.user.domain.model.vo;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Name {
+  private static final int MAX_LENGTH = 5;
+
+  @Column(name = "name", length = MAX_LENGTH, nullable = false)
+  private String value;
+
+  private Name(String value) {
+    validateName(value);
+    this.value = value;
+  }
+
+  public static Name of(String value) {
+    return new Name(value);
+  }
+
+  private void validateName(String name) {
+    if (name == null || name.isBlank()) {
+      throw new IllegalArgumentException("이름은 필수 입력값입니다");
+    }
+
+    if (name.length() > MAX_LENGTH) {
+      throw new IllegalArgumentException("이름은 " + MAX_LENGTH + "자 이내여야 합니다");
+    }
+  }
+}

--- a/user-service/src/main/java/shop/genieus/user/domain/model/vo/Password.java
+++ b/user-service/src/main/java/shop/genieus/user/domain/model/vo/Password.java
@@ -1,0 +1,46 @@
+package shop.genieus.user.domain.model.vo;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import shop.genieus.user.domain.model.service.PasswordEncryptionService;
+
+@Getter
+@Embeddable
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Password {
+  private static final int MIN_LENGTH = 8;
+  private static final int MAX_LENGTH = 20;
+  private static final String PASSWORD_PATTERN =
+      "^(?=.*[0-9])(?=.*[a-z])(?=.*[A-Z])(?=.*[!@#$%^&*()_+\\-=\\[\\]{}|;:,.<>?])(.{"
+          + MIN_LENGTH
+          + ","
+          + MAX_LENGTH
+          + "})$";
+
+  @Column(name = "password", length = 255, nullable = false)
+  private String value;
+
+  private Password(String value) {
+    this.value = value;
+  }
+
+  public static Password of(
+      String plainPassword, PasswordEncryptionService passwordEncryptionService) {
+    validatePassword(plainPassword);
+    return new Password(passwordEncryptionService.encode(plainPassword));
+  }
+
+  private static void validatePassword(String plainPassword) {
+    if (plainPassword == null || plainPassword.isBlank()) {
+      throw new IllegalArgumentException("비밀번호는 필수 입력값입니다");
+    }
+
+    if (!plainPassword.matches(PASSWORD_PATTERN)) {
+      throw new IllegalArgumentException(
+          "비밀번호는 " + MIN_LENGTH + "~" + MAX_LENGTH + "자 사이의 대문자, 소문자, 숫자, 특수문자를 모두 포함해야 합니다");
+    }
+  }
+}

--- a/user-service/src/main/java/shop/genieus/user/domain/model/vo/PhoneNumber.java
+++ b/user-service/src/main/java/shop/genieus/user/domain/model/vo/PhoneNumber.java
@@ -1,0 +1,41 @@
+package shop.genieus.user.domain.model.vo;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PhoneNumber {
+  private static final int MAX_LENGTH = 11;
+  private static final String PHONE_REGEX = "^\\d{11}$";
+
+  @Column(name = "phone", length = MAX_LENGTH, nullable = false)
+  private String value;
+
+  private PhoneNumber(String value) {
+    validatePhoneNumber(value);
+    this.value = value;
+  }
+
+  public static PhoneNumber of(String value) {
+    return new PhoneNumber(value);
+  }
+
+  private void validatePhoneNumber(String phoneNumber) {
+    if (phoneNumber == null || phoneNumber.isBlank()) {
+      throw new IllegalArgumentException("휴대폰 번호는 필수 입력값입니다");
+    }
+
+    if (phoneNumber.length() != MAX_LENGTH) {
+      throw new IllegalArgumentException("휴대폰 번호는 숫자 " + MAX_LENGTH + "자여야 합니다");
+    }
+
+    if (!phoneNumber.matches(PHONE_REGEX)) {
+      throw new IllegalArgumentException("휴대폰 번호는 숫자로만 이루어진 11자리여야 합니다");
+    }
+  }
+}

--- a/user-service/src/main/java/shop/genieus/user/domain/model/vo/Role.java
+++ b/user-service/src/main/java/shop/genieus/user/domain/model/vo/Role.java
@@ -1,0 +1,33 @@
+package shop.genieus.user.domain.model.vo;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Role {
+  @Column(name = "role", nullable = false)
+  @Enumerated(EnumType.STRING)
+  private RoleType value;
+
+  private Role(RoleType value) {
+    validateRole(value);
+    this.value = value;
+  }
+
+  public static Role of(RoleType value) {
+    return new Role(value);
+  }
+
+  private void validateRole(RoleType value) {
+    if (value == null) {
+      throw new IllegalArgumentException("권한은 필수 입력값입니다");
+    }
+  }
+}

--- a/user-service/src/main/java/shop/genieus/user/domain/model/vo/RoleType.java
+++ b/user-service/src/main/java/shop/genieus/user/domain/model/vo/RoleType.java
@@ -1,0 +1,15 @@
+package shop.genieus.user.domain.model.vo;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum RoleType {
+  MASTER_ADMIN("시스템 전체 관리자", "시스템의 모든 기능에 접근 가능한 최고 관리자"),
+  SHOP_ADMIN("상점 관리자", "특정 상점의 상품, 주문, 고객 관리 권한을 가진 관리자"),
+  CUSTOMER("일반 고객", "상품을 구매할 수 있는 일반 사용자"),
+  ;
+  private final String title;
+  private final String description;
+}

--- a/user-service/src/main/java/shop/genieus/user/global/config/JpaConfig.java
+++ b/user-service/src/main/java/shop/genieus/user/global/config/JpaConfig.java
@@ -1,0 +1,8 @@
+package shop.genieus.user.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaConfig {}

--- a/user-service/src/main/java/shop/genieus/user/global/config/PasswordSecurityConfig.java
+++ b/user-service/src/main/java/shop/genieus/user/global/config/PasswordSecurityConfig.java
@@ -1,0 +1,14 @@
+package shop.genieus.user.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+public class PasswordSecurityConfig {
+  @Bean
+  public PasswordEncoder passwordEncoder() {
+    return new BCryptPasswordEncoder();
+  }
+}

--- a/user-service/src/main/java/shop/genieus/user/infrastructure/support/encoder/BCryptPasswordEncryptionAdapter.java
+++ b/user-service/src/main/java/shop/genieus/user/infrastructure/support/encoder/BCryptPasswordEncryptionAdapter.java
@@ -1,0 +1,21 @@
+package shop.genieus.user.infrastructure.support.encoder;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import shop.genieus.user.application.out.support.encoder.PasswordEncryptionPort;
+
+@Component
+@RequiredArgsConstructor
+public class BCryptPasswordEncryptionAdapter implements PasswordEncryptionPort {
+  private final org.springframework.security.crypto.password.PasswordEncoder encoder;
+
+  @Override
+  public String encode(String rawPassword) {
+    return encoder.encode(rawPassword);
+  }
+
+  @Override
+  public boolean matches(String rawPassword, String encodedPassword) {
+    return encoder.matches(rawPassword, encodedPassword);
+  }
+}


### PR DESCRIPTION
## 개요
User 도메인의 엔티티 및 값 객체를 설계했습니다.

## 📝 작업 내용
### 변경 사항
- 사용자 도메인의 핵심 값 객체 구현
  - `Address`: 주소 값 객체
  - `BirthInfo`: 생년월일 및 성별 정보 값 객체
  - `Email`: 이메일 값 객체
  - `Gender`: 성별 열거형
  - `Name`: 이름 값 객체
  - `Password`: 비밀번호 값 객체
  - `PhoneNumber`: 전화번호 값 객체
  - `Role` 및 `RoleType`: 사용자 역할 값 객체
- 암호화 서비스 및 관련 컴포넌트 추가
  - `PasswordEncryptionService`: 도메인 레벨 암호화 서비스 인터페이스
  - `PasswordEncryptionPort`: 애플리케이션 계층 포트 인터페이스
  - `BCryptPasswordEncryptionAdapter`: BCrypt 기반 암호화 어댑터
  - `PasswordSecurityConfig`: 암호화 설정 빈

### 변경 이유

### 추가 설명
- 값 객체 자체 검증 로직 포함
- `of()` 메서드를 통한 객체 생성
- 유효성 검사를 통한 도메인 규칙 적용

<br/><br/>

<html><head></head><body><h2>값 객체 검증 규칙</h2>

값 객체 | 필드 | 검증 규칙 | 제한 사항
-- | -- | -- | --
Address | value | - 빈 값 허용 안 함<br>- 문자열 길이 검증 | 최대 길이 255자
BirthInfo | birthdate<br>gender | - 주민등록번호 앞 7자리 기준 생성<br>- 만 14세 이상 확인<br>- 미래 날짜 허용 안 함<br>- 성별 식별자 검증 | - 생년월일은 현재 날짜 이전<br>- 만 14세 이상
Email | value | - 이메일 정규식 검증<br>- 빈 값 허용 안 함<br>- 문자열 길이 검증 | - 최대 길이 20자<br>- 표준 이메일 형식 준수
Name | value | - 빈 값 허용 안 함<br>- 문자열 길이 검증 | 최대 길이 5자
Password | value | - 빈 값 허용 안 함<br>- 복합성 검증<br>- 암호화 서비스 사용 | - 길이 8~20자<br>- 대문자, 소문자, 숫자, 특수문자 필수 포함
PhoneNumber | value | - 빈 값 허용 안 함<br>- 숫자 형식 검증<br>- 문자열 길이 검증 | - 11자리 숫자<br>- 하이픈(-) 미포함
Role | value | - null 값 허용 안 함<br>- 미리 정의된 RoleType 사용 | 사전 정의된 RoleType 중 선택

</body></html>

## 💬 리뷰 요구사항
#### #️⃣ 연관된 이슈
closed #4

## PR 유형
- [x] 새로운 기능 추가

## ✅ Check List
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다. (버그 수정/기능에 대한 테스트)
- [ ] CI/CD 파이프라인을 통과했습니다.