### PR TITLE
[Feat] 인증 서비스 도메인, 엔티티, 값객체 설계

### DIFF
--- a/auth-service/.gitignore
+++ b/auth-service/.gitignore
@@ -34,3 +34,5 @@ out/
 
 ### VS Code ###
 .vscode/
+
+gradle.properties

--- a/auth-service/build.gradle
+++ b/auth-service/build.gradle
@@ -21,6 +21,14 @@ configurations {
 
 repositories {
     mavenCentral()
+    maven {
+        name = "GitHubPackages"
+        url = uri("https://maven.pkg.github.com/Genie-Uss/genieus-common-lib")
+        credentials {
+            username = project.findProperty("COMMON_GITHUB_USER") ?: System.getenv("COMMON_GITHUB_USER")
+            password = project.findProperty("COMMON_GITHUB_TOKEN") ?: System.getenv("COMMON_GITHUB_TOKEN")
+        }
+    }
 }
 
 ext {
@@ -36,6 +44,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 
     // database
     runtimeOnly 'com.mysql:mysql-connector-j'
@@ -49,6 +58,9 @@ dependencies {
     implementation 'io.github.openfeign:feign-micrometer'
     implementation 'io.micrometer:micrometer-tracing-bridge-brave'
     implementation 'io.zipkin.reporter2:zipkin-reporter-brave'
+
+    // etc
+    implementation 'com.genieus:genieus-common-lib:1.0.0'
 }
 
 dependencyManagement {

--- a/auth-service/src/main/java/shop/genieus/auth/application/out/support/encoder/PasswordEncryptionPort.java
+++ b/auth-service/src/main/java/shop/genieus/auth/application/out/support/encoder/PasswordEncryptionPort.java
@@ -1,0 +1,5 @@
+package shop.genieus.auth.application.out.support.encoder;
+
+import shop.genieus.auth.domain.model.service.PasswordEncryptionService;
+
+public interface PasswordEncryptionPort extends PasswordEncryptionService {}

--- a/auth-service/src/main/java/shop/genieus/auth/domain/model/Passport.java
+++ b/auth-service/src/main/java/shop/genieus/auth/domain/model/Passport.java
@@ -1,0 +1,71 @@
+package shop.genieus.auth.domain.model;
+
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import shop.genieus.auth.global.common.RoleType;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class Passport {
+  public static final int DEFAULT_SESSION_HOURS = 24;
+
+  private final String sessionId;
+  private Long userId;
+  private RoleType role;
+  private LocalDateTime issuedAt;
+  private LocalDateTime expiresAt;
+
+  private static Passport create(
+      String sessionId, Long userId, RoleType role, LocalDateTime now, int sessionHours) {
+    validatePassport(sessionId, userId, role, now);
+
+    return Passport.builder()
+        .sessionId(sessionId)
+        .userId(userId)
+        .role(role)
+        .issuedAt(now)
+        .expiresAt(now.plusHours(sessionHours))
+        .build();
+  }
+
+  public static Passport create(String sessionId, Long userId, RoleType role, LocalDateTime now) {
+    return create(sessionId, userId, role, now, DEFAULT_SESSION_HOURS);
+  }
+
+  private static void validatePassport(
+      String sessionId, Long userId, RoleType role, LocalDateTime issuedAt) {
+    if (sessionId == null || sessionId.isBlank()) {
+      throw new IllegalArgumentException("세션 ID는 빈 값일 수 없습니다.");
+    }
+    if (userId == null || userId <= 0) {
+      throw new IllegalArgumentException("유효하지 않은 사용자 ID입니다.");
+    }
+    if (role == null) {
+      throw new IllegalArgumentException("역할 정보는 필수입니다.");
+    }
+    if (issuedAt == null) {
+      throw new IllegalArgumentException("발급 시간은 필수입니다.");
+    }
+  }
+
+  public Passport extend(LocalDateTime now, int hours) {
+    if (now == null) {
+      throw new IllegalArgumentException("현재 시간은 필수입니다.");
+    }
+    if (hours <= 0) {
+      throw new IllegalArgumentException("연장 시간은 0보다 커야 합니다.");
+    }
+
+    return Passport.builder()
+        .sessionId(this.sessionId)
+        .userId(this.userId)
+        .role(this.role)
+        .issuedAt(this.issuedAt)
+        .expiresAt(now.plusHours(hours))
+        .build();
+  }
+}

--- a/auth-service/src/main/java/shop/genieus/auth/domain/model/TokenPair.java
+++ b/auth-service/src/main/java/shop/genieus/auth/domain/model/TokenPair.java
@@ -1,0 +1,116 @@
+package shop.genieus.auth.domain.model;
+
+import java.time.Instant;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import shop.genieus.auth.domain.model.vo.TokenCredential;
+import shop.genieus.auth.domain.model.vo.TokenId;
+import shop.genieus.auth.domain.model.vo.TokenType;
+
+@Getter
+@Builder(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class TokenPair {
+  private final TokenId tokenId;
+  private TokenCredential accessTokenCredential;
+  private TokenCredential refreshTokenCredential;
+
+  public static TokenPair create(
+      String tokenIdValue,
+      String accessTokenValue,
+      String refreshTokenValue,
+      Long subject,
+      Instant issuedAt) {
+    validateCreateParams(tokenIdValue, accessTokenValue, refreshTokenValue, subject, issuedAt);
+
+    Instant accessTokenExpiration = TokenType.ACCESS.calculateExpiration(issuedAt);
+    Instant refreshTokenExpiration = TokenType.REFRESH.calculateExpiration(issuedAt);
+
+    return TokenPair.create(
+        tokenIdValue,
+        accessTokenValue,
+        refreshTokenValue,
+        subject,
+        issuedAt,
+        accessTokenExpiration,
+        issuedAt,
+        refreshTokenExpiration);
+  }
+
+  private static TokenPair create(
+      String tokenIdValue,
+      String accessToken,
+      String refreshToken,
+      Long subject,
+      Instant accessTokenIssuedAt,
+      Instant accessTokenExpiration,
+      Instant refreshTokenIssuedAt,
+      Instant refreshTokenExpiration) {
+    TokenId tokenId = TokenId.of(tokenIdValue);
+
+    TokenCredential accessTokenCredential =
+        createAccessTokenCredential(
+            accessToken, subject, accessTokenIssuedAt, accessTokenExpiration);
+
+    TokenCredential refreshTokenCredential =
+        createRefreshTokenCredential(
+            refreshToken, subject, refreshTokenIssuedAt, refreshTokenExpiration);
+
+    validateTokenPair(accessTokenCredential, refreshTokenCredential);
+
+    return TokenPair.builder()
+        .tokenId(tokenId)
+        .accessTokenCredential(accessTokenCredential)
+        .refreshTokenCredential(refreshTokenCredential)
+        .build();
+  }
+
+  private static TokenCredential createAccessTokenCredential(
+      String token, Long subject, Instant issuedAt, Instant expiration) {
+    return TokenCredential.accessTokenOf(token, subject, issuedAt, expiration);
+  }
+
+  private static TokenCredential createRefreshTokenCredential(
+      String token, Long subject, Instant issuedAt, Instant expiration) {
+    return TokenCredential.refreshTokenOf(token, subject, issuedAt, expiration);
+  }
+
+  private static void validateTokenPair(
+      TokenCredential accessTokenCredential, TokenCredential refreshTokenCredential) {
+    if (!(accessTokenCredential.isAccessToken() && refreshTokenCredential.isRefreshToken())) {
+      throw new IllegalArgumentException("유효하지 않은 토큰 타입입니다.");
+    }
+
+    Long accessSubject = accessTokenCredential.claims().subject();
+    Long refreshSubject = refreshTokenCredential.claims().subject();
+
+    if (!accessSubject.equals(refreshSubject)) {
+      throw new IllegalArgumentException("액세스 토큰과 리프레시 토큰이 일치하지 않습니다.");
+    }
+  }
+
+  private static void validateCreateParams(
+      String tokenIdValue,
+      String accessTokenValue,
+      String refreshTokenValue,
+      Long subject,
+      Instant issuedAt) {
+    if (tokenIdValue == null || tokenIdValue.isBlank()) {
+      throw new IllegalArgumentException("토큰 ID는 빈 값일 수 없습니다.");
+    }
+    if (accessTokenValue == null || accessTokenValue.isBlank()) {
+      throw new IllegalArgumentException("액세스 토큰 값은 빈 값일 수 없습니다.");
+    }
+    if (refreshTokenValue == null || refreshTokenValue.isBlank()) {
+      throw new IllegalArgumentException("리프레시 토큰 값은 빈 값일 수 없습니다.");
+    }
+    if (subject == null || subject <= 0) {
+      throw new IllegalArgumentException("유효하지 않은 사용자 ID입니다.");
+    }
+    if (issuedAt == null) {
+      throw new IllegalArgumentException("발급 시간은 필수입니다.");
+    }
+  }
+}

--- a/auth-service/src/main/java/shop/genieus/auth/domain/model/entity/BaseEntity.java
+++ b/auth-service/src/main/java/shop/genieus/auth/domain/model/entity/BaseEntity.java
@@ -1,0 +1,55 @@
+package shop.genieus.auth.domain.model.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import org.hibernate.annotations.Comment;
+import org.hibernate.annotations.CurrentTimestamp;
+import org.springframework.data.annotation.CreatedBy;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedBy;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseEntity {
+
+  @CreatedDate
+  @Column(name = "created_at", nullable = false, updatable = false)
+  @CurrentTimestamp
+  @Comment("생성 일시")
+  private LocalDateTime createdAt;
+
+  @CreatedBy
+  @Column(name = "created_by", nullable = false, updatable = false)
+  @Comment("생성자")
+  private Long createdBy;
+
+  @LastModifiedDate
+  @Column(name = "updated_at", insertable = false)
+  @CurrentTimestamp
+  @Comment("수정 일시")
+  private LocalDateTime updatedAt;
+
+  @LastModifiedBy
+  @Column(name = "updated_by", insertable = false)
+  @Comment("수정자")
+  private Long updatedBy;
+
+  @Column(name = "deleted_at")
+  @Comment("삭제 일시")
+  private LocalDateTime deletedAt;
+
+  @Column(name = "deleted_by")
+  @Comment("삭제자")
+  private Long deletedBy;
+
+  public void delete(Long id) {
+    this.deletedAt = LocalDateTime.now();
+    this.deletedBy = id;
+  }
+}

--- a/auth-service/src/main/java/shop/genieus/auth/domain/model/entity/User.java
+++ b/auth-service/src/main/java/shop/genieus/auth/domain/model/entity/User.java
@@ -1,0 +1,65 @@
+package shop.genieus.auth.domain.model.entity;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Comment;
+import shop.genieus.auth.domain.model.service.PasswordEncryptionService;
+import shop.genieus.auth.domain.model.vo.Email;
+import shop.genieus.auth.domain.model.vo.Password;
+import shop.genieus.auth.domain.model.vo.Role;
+import shop.genieus.auth.global.common.RoleType;
+
+@Entity
+@Getter
+@Builder
+@Comment("사용자 테이블")
+@Table(name = "m_auth_user")
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class User extends BaseEntity {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "user_id")
+  private Long id;
+
+  @Embedded
+  @Comment("사용자 로그인 아이디(이메일)")
+  private Email email;
+
+  @Embedded
+  @Comment("비밀번호 정보")
+  @JsonIgnore
+  private Password password;
+
+  @Embedded
+  @Comment("사용자 권한")
+  private Role role;
+
+  @Builder.Default
+  @Comment("활성화 상태")
+  @Column(name = "is_active")
+  private boolean isActive = true;
+
+  public static User create(
+      String email,
+      String password,
+      PasswordEncryptionService passwordEncryptionService,
+      RoleType roleType) {
+    return User.builder()
+        .email(Email.of(email))
+        .password(Password.of(password, passwordEncryptionService))
+        .role(Role.of(roleType))
+        .build();
+  }
+}

--- a/auth-service/src/main/java/shop/genieus/auth/domain/model/service/PasswordEncryptionService.java
+++ b/auth-service/src/main/java/shop/genieus/auth/domain/model/service/PasswordEncryptionService.java
@@ -1,0 +1,7 @@
+package shop.genieus.auth.domain.model.service;
+
+public interface PasswordEncryptionService {
+  String encode(String rawPassword);
+
+  boolean matches(String rawPassword, String encodedPassword);
+}

--- a/auth-service/src/main/java/shop/genieus/auth/domain/model/vo/Email.java
+++ b/auth-service/src/main/java/shop/genieus/auth/domain/model/vo/Email.java
@@ -1,0 +1,24 @@
+package shop.genieus.auth.domain.model.vo;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import shop.genieus.auth.global.common.AbstractEmail;
+
+@Embeddable
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Email extends AbstractEmail {
+
+  @Column(name = "email", length = 20, unique = true, nullable = false)
+  private String value; // 필드 재정의 (JPA 매핑을 위함)
+
+  private Email(String value) {
+    validate(value); // 공통 검증 로직 사용
+    this.value = value;
+  }
+
+  public static Email of(String value) {
+    return new Email(value);
+  }
+}

--- a/auth-service/src/main/java/shop/genieus/auth/domain/model/vo/JwtAssociation.java
+++ b/auth-service/src/main/java/shop/genieus/auth/domain/model/vo/JwtAssociation.java
@@ -1,0 +1,15 @@
+package shop.genieus.auth.domain.model.vo;
+
+public record JwtAssociation(TokenId tokenId, Long userId) {
+  public JwtAssociation of(String tokenIdValue, Long userId) {
+    TokenId tokenId = TokenId.of(tokenIdValue);
+    validateUserId(userId);
+    return new JwtAssociation(tokenId, userId);
+  }
+
+  private void validateUserId(Long userId) {
+    if (userId == null) {
+      throw new IllegalArgumentException("사용자 ID는 필수입니다.");
+    }
+  }
+}

--- a/auth-service/src/main/java/shop/genieus/auth/domain/model/vo/Password.java
+++ b/auth-service/src/main/java/shop/genieus/auth/domain/model/vo/Password.java
@@ -1,0 +1,31 @@
+package shop.genieus.auth.domain.model.vo;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import shop.genieus.auth.domain.model.service.PasswordEncryptionService;
+
+@Getter
+@Embeddable
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Password {
+
+  @Column(name = "password", length = 255, nullable = false)
+  private String value;
+
+  public static Password of(
+      String plainPassword, PasswordEncryptionService passwordEncryptionService) {
+    validatePassword(plainPassword);
+    return new Password(passwordEncryptionService.encode(plainPassword));
+  }
+
+  private static void validatePassword(String plainPassword) {
+    if (plainPassword == null || plainPassword.isBlank()) {
+      throw new IllegalArgumentException("비밀번호는 필수 입력값입니다");
+    }
+  }
+}

--- a/auth-service/src/main/java/shop/genieus/auth/domain/model/vo/Role.java
+++ b/auth-service/src/main/java/shop/genieus/auth/domain/model/vo/Role.java
@@ -1,0 +1,28 @@
+package shop.genieus.auth.domain.model.vo;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import shop.genieus.auth.global.common.AbstractRole;
+import shop.genieus.auth.global.common.RoleType;
+
+@Embeddable
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Role extends AbstractRole {
+
+  @Column(name = "role", nullable = false)
+  @Enumerated(EnumType.STRING)
+  private RoleType value;
+
+  private Role(RoleType value) {
+    validateRole(value);
+    this.value = value;
+  }
+
+  public static Role of(RoleType value) {
+    return new Role(value);
+  }
+}

--- a/auth-service/src/main/java/shop/genieus/auth/domain/model/vo/TokenClaims.java
+++ b/auth-service/src/main/java/shop/genieus/auth/domain/model/vo/TokenClaims.java
@@ -1,0 +1,29 @@
+package shop.genieus.auth.domain.model.vo;
+
+import java.time.Instant;
+
+public record TokenClaims(Long subject, Instant issuedAt, Instant expiration) {
+
+  public TokenClaims {
+    if (subject == null) {
+      throw new IllegalArgumentException("발급자는 필수입니다.");
+    }
+    validateInstants(issuedAt, expiration);
+  }
+
+  public static TokenClaims of(Long subject, Instant issuedAt, Instant expiration) {
+    return new TokenClaims(subject, issuedAt, expiration);
+  }
+
+  private static void validateInstants(Instant issuedAt, Instant expiration) {
+    if (issuedAt == null) {
+      throw new IllegalArgumentException("세션 정보가 필요합니다.");
+    }
+    if (expiration == null) {
+      throw new IllegalArgumentException("만료일(expiration)은 필수입니다.");
+    }
+    if (expiration.isBefore(issuedAt)) {
+      throw new IllegalArgumentException("만료일은 발급일보다 이후여야 합니다.");
+    }
+  }
+}

--- a/auth-service/src/main/java/shop/genieus/auth/domain/model/vo/TokenCredential.java
+++ b/auth-service/src/main/java/shop/genieus/auth/domain/model/vo/TokenCredential.java
@@ -1,0 +1,43 @@
+package shop.genieus.auth.domain.model.vo;
+
+import java.time.Instant;
+
+public record TokenCredential(String tokenValue, TokenType tokenType, TokenClaims claims) {
+
+  public TokenCredential {
+    validateTokenValue(tokenValue);
+    validateTokenType(tokenType);
+  }
+
+  public static TokenCredential accessTokenOf(
+      String tokenValue, Long subject, Instant issuedAt, Instant expiration) {
+    TokenClaims claims = TokenClaims.of(subject, issuedAt, expiration);
+    return new TokenCredential(tokenValue, TokenType.ACCESS, claims);
+  }
+
+  public static TokenCredential refreshTokenOf(
+      String tokenValue, Long subject, Instant issuedAt, Instant expiration) {
+    TokenClaims claims = TokenClaims.of(subject, issuedAt, expiration);
+    return new TokenCredential(tokenValue, TokenType.REFRESH, claims);
+  }
+
+  private static void validateTokenValue(String tokenValue) {
+    if (tokenValue == null || tokenValue.isBlank()) {
+      throw new IllegalArgumentException("토큰 값은 빈 값일 수 없습니다.");
+    }
+  }
+
+  private static void validateTokenType(TokenType tokenType) {
+    if (tokenType == null) {
+      throw new IllegalArgumentException("유효하지 않은 토큰 타입입니다.");
+    }
+  }
+
+  public boolean isAccessToken() {
+    return this.tokenType == TokenType.ACCESS;
+  }
+
+  public boolean isRefreshToken() {
+    return this.tokenType == TokenType.REFRESH;
+  }
+}

--- a/auth-service/src/main/java/shop/genieus/auth/domain/model/vo/TokenId.java
+++ b/auth-service/src/main/java/shop/genieus/auth/domain/model/vo/TokenId.java
@@ -1,0 +1,18 @@
+package shop.genieus.auth.domain.model.vo;
+
+public record TokenId(String value) {
+
+  public TokenId {
+    validateTokenId(value);
+  }
+
+  public static TokenId of(String value) {
+    return new TokenId(value);
+  }
+
+  private static void validateTokenId(String value) {
+    if (value == null || value.isBlank()) {
+      throw new IllegalArgumentException("토큰 ID는 빈 값일 수 없습니다.");
+    }
+  }
+}

--- a/auth-service/src/main/java/shop/genieus/auth/domain/model/vo/TokenType.java
+++ b/auth-service/src/main/java/shop/genieus/auth/domain/model/vo/TokenType.java
@@ -1,0 +1,21 @@
+package shop.genieus.auth.domain.model.vo;
+
+import java.time.Duration;
+import java.time.Instant;
+import lombok.Getter;
+
+@Getter
+public enum TokenType {
+  ACCESS(Duration.ofMinutes(15)),
+  REFRESH(Duration.ofDays(7));
+
+  private final Duration expiration;
+
+  TokenType(Duration expiration) {
+    this.expiration = expiration;
+  }
+
+  public Instant calculateExpiration(Instant issuedAt) {
+    return issuedAt.plus(expiration);
+  }
+}

--- a/auth-service/src/main/java/shop/genieus/auth/global/common/AbstractEmail.java
+++ b/auth-service/src/main/java/shop/genieus/auth/global/common/AbstractEmail.java
@@ -1,0 +1,27 @@
+package shop.genieus.auth.global.common;
+
+import lombok.Getter;
+
+@Getter
+public abstract class AbstractEmail {
+  private static final int MAX_LENGTH = 20;
+  private static final String EMAIL_REGEX =
+      "^[a-zA-Z0-9_+&*-]+(?:\\.[a-zA-Z0-9_+&*-]+)*@(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,7}$";
+
+  protected String value;
+
+  protected void validate(String value) {
+    if (value == null || value.isBlank()) {
+      throw new IllegalArgumentException("이메일은 필수 입력값입니다");
+    }
+
+    if (!value.matches(EMAIL_REGEX)) {
+      throw new IllegalArgumentException(
+          "이메일 형식이 올바르지 않습니다. 이메일은 영문자, 숫자, 특수문자(_+&*-)로 구성된 아이디와 도메인으로 구성되어야 합니다.");
+    }
+
+    if (value.length() > MAX_LENGTH) {
+      throw new IllegalArgumentException("이메일은 " + MAX_LENGTH + "자를 초과할 수 없습니다");
+    }
+  }
+}

--- a/auth-service/src/main/java/shop/genieus/auth/global/common/AbstractRole.java
+++ b/auth-service/src/main/java/shop/genieus/auth/global/common/AbstractRole.java
@@ -1,0 +1,14 @@
+package shop.genieus.auth.global.common;
+
+import lombok.Getter;
+
+@Getter
+public abstract class AbstractRole {
+  protected RoleType value;
+
+  protected void validateRole(RoleType value) {
+    if (value == null) {
+      throw new IllegalArgumentException("권한은 필수 입력값입니다");
+    }
+  }
+}

--- a/auth-service/src/main/java/shop/genieus/auth/global/common/GenieusPasswordEncoder.java
+++ b/auth-service/src/main/java/shop/genieus/auth/global/common/GenieusPasswordEncoder.java
@@ -1,0 +1,17 @@
+package shop.genieus.auth.global.common;
+
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.stereotype.Component;
+
+@Component
+public class GenieusPasswordEncoder {
+  private final BCryptPasswordEncoder encoder = new BCryptPasswordEncoder();
+
+  public String encode(CharSequence rawPassword) {
+    return encoder.encode(rawPassword);
+  }
+
+  public boolean matches(CharSequence rawPassword, String encodedPassword) {
+    return encoder.matches(rawPassword, encodedPassword);
+  }
+}

--- a/auth-service/src/main/java/shop/genieus/auth/global/common/RoleType.java
+++ b/auth-service/src/main/java/shop/genieus/auth/global/common/RoleType.java
@@ -1,4 +1,4 @@
-package shop.genieus.user.domain.model.vo;
+package shop.genieus.auth.global.common;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;

--- a/auth-service/src/main/java/shop/genieus/auth/global/config/PasswordSecurityConfig.java
+++ b/auth-service/src/main/java/shop/genieus/auth/global/config/PasswordSecurityConfig.java
@@ -1,0 +1,13 @@
+package shop.genieus.auth.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import shop.genieus.auth.global.common.GenieusPasswordEncoder;
+
+@Configuration
+public class PasswordSecurityConfig {
+  @Bean
+  public GenieusPasswordEncoder passwordEncoder() {
+    return new GenieusPasswordEncoder();
+  }
+}

--- a/auth-service/src/main/java/shop/genieus/auth/infrastructure/support/encoder/BCryptPasswordEncryptionAdapter.java
+++ b/auth-service/src/main/java/shop/genieus/auth/infrastructure/support/encoder/BCryptPasswordEncryptionAdapter.java
@@ -1,0 +1,22 @@
+package shop.genieus.auth.infrastructure.support.encoder;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import shop.genieus.auth.application.out.support.encoder.PasswordEncryptionPort;
+import shop.genieus.auth.global.common.GenieusPasswordEncoder;
+
+@Component
+@RequiredArgsConstructor
+public class BCryptPasswordEncryptionAdapter implements PasswordEncryptionPort {
+  private final GenieusPasswordEncoder genieusPasswordEncoder;
+
+  @Override
+  public String encode(String rawPassword) {
+    return genieusPasswordEncoder.encode(rawPassword);
+  }
+
+  @Override
+  public boolean matches(String rawPassword, String encodedPassword) {
+    return genieusPasswordEncoder.matches(rawPassword, encodedPassword);
+  }
+}


### PR DESCRIPTION
## 개요

인증 서비스의 핵심 도메인 모델과 값 객체들을 구현했습니다. 공통 라이브러리 의존성을 추가하고 도메인 레이어의 기본 구조를 설계했습니다.

## 📝 작업 내용

### 변경 사항

1. 공통 라이브러리 의존성 추가 (`genieus-common-lib:1.0.0`)
2. 핵심 도메인 모델 추가:
   - `TokenPair` - 액세스/리프레시 토큰 쌍 관리
   - `Passport` - 사용자 인증 세션 정보
   - `User` - 인증 사용자 엔티티
3. 값 객체(Value Object) 구현:
   - `TokenId`, `TokenCredential`, `TokenClaims`, `TokenType` 등 토큰 관련 VO
   - `Email`, `Password`, `Role` - 사용자 정보 관련 VO
   - `JwtAssociation` - JWT 토큰과 사용자 연결 VO
4. 추상 클래스 기반 공통 로직 분리, 비밀번호 암호화 로직 분리: 추후 공통 라이브러리에 추가
   - `AbstractEmail`, `AbstractRole`, `GenieusPasswordEncoder`은 유저 서비스와 비즈니스 검증 로직 공유
5. 인프라 계층 구현:
   - `BCryptPasswordEncryptionAdapter` - 비밀번호 암호화 어댑터

### 변경 이유

1. **도메인 모델 중심 설계**: 인증 프로세스의 핵심 개념(토큰, 사용자, 인증)을 명확한 도메인 모델로 표현
2. **공통 로직 재사용**: 추상 클래스를 활용해 이메일, 역할 등의 검증 로직 재사용

### 추가 설명


#### 값 객체 검증 규칙

| 값 객체 | 필드 | 검증 규칙 | 제한 사항 |
| -- | -- | -- | -- |
| Email | value | - 빈 값 허용 안 함<br>- 이메일 정규식 검증<br>- 문자열 길이 검증 | - 최대 길이 20자<br>- 표준 이메일 형식 준수 |
| Password | value | - 빈 값 허용 안 함<br>- PasswordEncryptionService 활용 | - 암호화된 값 저장 |
| Role | value | - null 값 허용 안 함<br>- RoleType enum 사용 | 사전 정의된 RoleType 중 선택 |
| TokenId | value | - 빈 값 허용 안 함 | JWT의 고유 식별자(jti) |
| TokenClaims | subject<br>issuedAt<br>expiration | - 모든 필드 필수<br>- 만료일은 발급일 이후여야 함 | - 토큰 클레임 정보 캡슐화 |
| TokenCredential | tokenValue<br>tokenType<br>claims | - 토큰 값은 빈 값 허용 안 함<br>- 토큰 타입 필수<br>- claims 객체 유효성 검증 | - ACCESS/REFRESH 토큰 타입 중 선택 |
| JwtAssociation | tokenId<br>userId | - 토큰 ID, 사용자 ID 필수 | - JWT와 사용자 ID 연결 정보 |

## 💬 리뷰 요구사항


#### #️⃣ 연관된 이슈
closed #9

## PR 유형

이 PR은 어떤 변경 사항을 포함하고 있나요?

- [X] 새로운 기능 추가

## ✅ Check List

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [X] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다. (버그 수정/기능에 대한 테스트)
- [ ] CI/CD 파이프라인을 통과했습니다.