### PR TITLE
[Feat] 인증 서비스 JWT 기반 로그인 구현

### DIFF
--- a/auth-service/build.gradle
+++ b/auth-service/build.gradle
@@ -45,9 +45,11 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
 
     // database
     runtimeOnly 'com.mysql:mysql-connector-j'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
     // msa
     implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
@@ -61,6 +63,9 @@ dependencies {
 
     // etc
     implementation 'com.genieus:genieus-common-lib:1.0.0'
+    compileOnly 'io.jsonwebtoken:jjwt-api:0.11.5'           // security (JWT)
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 }
 
 dependencyManagement {

--- a/auth-service/src/main/java/shop/genieus/auth/application/in/command/AuthenticationCommandService.java
+++ b/auth-service/src/main/java/shop/genieus/auth/application/in/command/AuthenticationCommandService.java
@@ -1,0 +1,48 @@
+package shop.genieus.auth.application.in.command;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import shop.genieus.auth.application.in.command.dto.LoginCommand;
+import shop.genieus.auth.application.out.persistence.AuthPersistencePort;
+import shop.genieus.auth.application.out.support.encoder.PasswordEncryptionPort;
+import shop.genieus.auth.application.out.support.id.IdGeneratorPort;
+import shop.genieus.auth.application.out.support.token.AuthTokenPort;
+import shop.genieus.auth.domain.model.TokenPair;
+import shop.genieus.auth.domain.model.entity.User;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+@Slf4j(topic = "[AuthenticationCommandService]")
+public class AuthenticationCommandService {
+  private final AuthPersistencePort persistencePort;
+  private final AuthTokenPort tokenPort;
+  private final PasswordEncryptionPort encryptionPort;
+  private final IdGeneratorPort idGenerator;
+
+  public TokenPair login(final LoginCommand command) {
+    User user = persistencePort.findByEmail(command.username());
+
+    if (!user.isActive()) {
+      throw new IllegalArgumentException("비활성화된 사용자입니다.");
+    }
+    if (!user.matchPassword(command.password(), encryptionPort)) {
+      throw new IllegalArgumentException("입력하신 아이디 또는 비밀번호가 잘못되었습니다.");
+    }
+
+    TokenPair tokenPair = createAndSaveTokenPair(user.getId());
+    log.info("로그인 성공, 유저 로그인 아이디: {}", user.getEmail());
+
+    return tokenPair;
+  }
+
+  private TokenPair createAndSaveTokenPair(Long userId) {
+    String tokenId = idGenerator.generateUniqueId();
+    TokenPair tokenPair = tokenPort.createTokenPair(tokenId, userId);
+    persistencePort.saveRefreshToken(
+        tokenPair.getTokenId(), userId, tokenPair.getRefreshTokenCredential());
+    return tokenPair;
+  }
+}

--- a/auth-service/src/main/java/shop/genieus/auth/application/in/command/dto/LoginCommand.java
+++ b/auth-service/src/main/java/shop/genieus/auth/application/in/command/dto/LoginCommand.java
@@ -1,0 +1,3 @@
+package shop.genieus.auth.application.in.command.dto;
+
+public record LoginCommand(String username, String password) {}

--- a/auth-service/src/main/java/shop/genieus/auth/application/out/persistence/AuthPersistencePort.java
+++ b/auth-service/src/main/java/shop/genieus/auth/application/out/persistence/AuthPersistencePort.java
@@ -1,0 +1,11 @@
+package shop.genieus.auth.application.out.persistence;
+
+import shop.genieus.auth.domain.model.entity.User;
+import shop.genieus.auth.domain.model.vo.TokenCredential;
+import shop.genieus.auth.domain.model.vo.TokenId;
+
+public interface AuthPersistencePort {
+  User findByEmail(String username);
+
+  void saveRefreshToken(TokenId tokenId, Long userId, TokenCredential refreshTokenCredential);
+}

--- a/auth-service/src/main/java/shop/genieus/auth/application/out/support/id/IdGeneratorPort.java
+++ b/auth-service/src/main/java/shop/genieus/auth/application/out/support/id/IdGeneratorPort.java
@@ -1,0 +1,5 @@
+package shop.genieus.auth.application.out.support.id;
+
+public interface IdGeneratorPort {
+  String generateUniqueId();
+}

--- a/auth-service/src/main/java/shop/genieus/auth/application/out/support/token/AuthTokenPort.java
+++ b/auth-service/src/main/java/shop/genieus/auth/application/out/support/token/AuthTokenPort.java
@@ -1,0 +1,7 @@
+package shop.genieus.auth.application.out.support.token;
+
+import shop.genieus.auth.domain.model.TokenPair;
+
+public interface AuthTokenPort {
+  TokenPair createTokenPair(String tokenId, Long userId);
+}

--- a/auth-service/src/main/java/shop/genieus/auth/domain/model/entity/User.java
+++ b/auth-service/src/main/java/shop/genieus/auth/domain/model/entity/User.java
@@ -62,4 +62,9 @@ public class User extends BaseEntity {
         .role(Role.of(roleType))
         .build();
   }
+
+  public boolean matchPassword(
+      String plainPassword, PasswordEncryptionService passwordEncryptionService) {
+    return this.password.matches(plainPassword, passwordEncryptionService);
+  }
 }

--- a/auth-service/src/main/java/shop/genieus/auth/domain/model/vo/Password.java
+++ b/auth-service/src/main/java/shop/genieus/auth/domain/model/vo/Password.java
@@ -28,4 +28,9 @@ public class Password {
       throw new IllegalArgumentException("비밀번호는 필수 입력값입니다");
     }
   }
+
+  public boolean matches(
+      String plainPassword, PasswordEncryptionService passwordEncryptionService) {
+    return passwordEncryptionService.matches(plainPassword, this.value);
+  }
 }

--- a/auth-service/src/main/java/shop/genieus/auth/global/config/JwtConfig.java
+++ b/auth-service/src/main/java/shop/genieus/auth/global/config/JwtConfig.java
@@ -1,0 +1,29 @@
+package shop.genieus.auth.global.config;
+
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+import java.security.Key;
+import java.util.Base64;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@RequiredArgsConstructor
+public class JwtConfig {
+  @Value("${jwt.secret}")
+  private String secret;
+
+  @Getter private Key key;
+
+  @PostConstruct
+  public void init() {
+    try {
+      byte[] bytes = Base64.getDecoder().decode(secret);
+      key = Keys.hmacShaKeyFor(bytes);
+    } catch (Exception e) {
+      throw new RuntimeException("JWT 비밀키 초기화 실패", e);
+    }
+  }
+}

--- a/auth-service/src/main/java/shop/genieus/auth/infrastructure/persistence/AuthPersistenceAdapter.java
+++ b/auth-service/src/main/java/shop/genieus/auth/infrastructure/persistence/AuthPersistenceAdapter.java
@@ -1,0 +1,37 @@
+package shop.genieus.auth.infrastructure.persistence;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import shop.genieus.auth.application.out.persistence.AuthPersistencePort;
+import shop.genieus.auth.domain.model.entity.User;
+import shop.genieus.auth.domain.model.vo.Email;
+import shop.genieus.auth.domain.model.vo.TokenCredential;
+import shop.genieus.auth.domain.model.vo.TokenId;
+import shop.genieus.auth.infrastructure.persistence.repository.TokenRedisRepository;
+import shop.genieus.auth.infrastructure.persistence.repository.UserJpaRepository;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j(topic = "[AuthPersistenceAdapter]")
+public class AuthPersistenceAdapter implements AuthPersistencePort {
+  private final UserJpaRepository userJpaRepository;
+  private final TokenRedisRepository tokenRedisRepository;
+
+  @Override
+  public User findByEmail(String username) {
+    return userJpaRepository
+        .findByEmailNotDeleted(Email.of(username))
+        .orElseThrow(() -> new IllegalArgumentException("입력하신 아이디 또는 비밀번호가 잘못되었습니다."));
+  }
+
+  @Override
+  public void saveRefreshToken(
+      TokenId tokenId, Long userId, TokenCredential refreshTokenCredential) {
+    long ttlMillis = refreshTokenCredential.tokenType().getExpiration().toMillis();
+    String tokenValue = tokenId.value();
+    tokenRedisRepository.saveRefreshToken(
+        tokenValue, userId, refreshTokenCredential.tokenValue(), ttlMillis);
+    log.info("리프레시 토큰 저장: userId={}, tokenId={}", userId, tokenValue);
+  }
+}

--- a/auth-service/src/main/java/shop/genieus/auth/infrastructure/persistence/repository/TokenRedisRepository.java
+++ b/auth-service/src/main/java/shop/genieus/auth/infrastructure/persistence/repository/TokenRedisRepository.java
@@ -1,0 +1,27 @@
+package shop.genieus.auth.infrastructure.persistence.repository;
+
+import java.util.Arrays;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Repository;
+import shop.genieus.auth.infrastructure.persistence.util.LuaScriptProvider;
+
+@Repository
+@RequiredArgsConstructor
+public class TokenRedisRepository {
+  private static final String REFRESH_TOKEN_PREFIX = "refresh:token:";
+  private static final String USER_TOKENS_PREFIX = "user:tokens:";
+  private final StringRedisTemplate redisTemplate;
+
+  public void saveRefreshToken(String tokenId, Long userId, String refreshToken, long ttlMillis) {
+    List<String> keys = Arrays.asList(REFRESH_TOKEN_PREFIX + tokenId, USER_TOKENS_PREFIX + userId);
+
+    redisTemplate.execute(
+        LuaScriptProvider.getSaveRefreshTokenScript(),
+        keys,
+        refreshToken,
+        String.valueOf(ttlMillis),
+        tokenId);
+  }
+}

--- a/auth-service/src/main/java/shop/genieus/auth/infrastructure/persistence/repository/UserJpaRepository.java
+++ b/auth-service/src/main/java/shop/genieus/auth/infrastructure/persistence/repository/UserJpaRepository.java
@@ -1,0 +1,13 @@
+package shop.genieus.auth.infrastructure.persistence.repository;
+
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import shop.genieus.auth.domain.model.entity.User;
+import shop.genieus.auth.domain.model.vo.Email;
+
+public interface UserJpaRepository extends JpaRepository<User, String> {
+  @Query("SELECT u FROM User u WHERE u.email = :email AND u.deletedAt IS NULL")
+  Optional<User> findByEmailNotDeleted(@Param("email") Email email);
+}

--- a/auth-service/src/main/java/shop/genieus/auth/infrastructure/persistence/util/LuaScriptProvider.java
+++ b/auth-service/src/main/java/shop/genieus/auth/infrastructure/persistence/util/LuaScriptProvider.java
@@ -1,0 +1,23 @@
+package shop.genieus.auth.infrastructure.persistence.util;
+
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.data.redis.core.script.DefaultRedisScript;
+import org.springframework.data.redis.core.script.RedisScript;
+import org.springframework.scripting.support.ResourceScriptSource;
+
+public class LuaScriptProvider {
+
+  private static final RedisScript<Long> SAVE_REFRESH_TOKEN_SCRIPT;
+
+  static {
+    DefaultRedisScript<Long> script = new DefaultRedisScript<>();
+    script.setScriptSource(
+        new ResourceScriptSource(new ClassPathResource("redis/save-refresh-token.lua")));
+    script.setResultType(Long.class);
+    SAVE_REFRESH_TOKEN_SCRIPT = script;
+  }
+
+  public static RedisScript<Long> getSaveRefreshTokenScript() {
+    return SAVE_REFRESH_TOKEN_SCRIPT;
+  }
+}

--- a/auth-service/src/main/java/shop/genieus/auth/infrastructure/support/id/UuidGeneratorAdapter.java
+++ b/auth-service/src/main/java/shop/genieus/auth/infrastructure/support/id/UuidGeneratorAdapter.java
@@ -1,0 +1,14 @@
+package shop.genieus.auth.infrastructure.support.id;
+
+import java.util.UUID;
+import org.springframework.stereotype.Component;
+import shop.genieus.auth.application.out.support.id.IdGeneratorPort;
+
+@Component
+public class UuidGeneratorAdapter implements IdGeneratorPort {
+
+  @Override
+  public String generateUniqueId() {
+    return UUID.randomUUID().toString();
+  }
+}

--- a/auth-service/src/main/java/shop/genieus/auth/infrastructure/support/token/AuthJwtAdapter.java
+++ b/auth-service/src/main/java/shop/genieus/auth/infrastructure/support/token/AuthJwtAdapter.java
@@ -1,0 +1,23 @@
+package shop.genieus.auth.infrastructure.support.token;
+
+import java.time.Instant;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import shop.genieus.auth.application.out.support.token.AuthTokenPort;
+import shop.genieus.auth.domain.model.TokenPair;
+import shop.genieus.auth.infrastructure.support.token.util.JwtProvider;
+
+@Component
+@RequiredArgsConstructor
+public class AuthJwtAdapter implements AuthTokenPort {
+  private final JwtProvider jwtProvider;
+
+  @Override
+  public TokenPair createTokenPair(String tokenIdValue, Long subject) {
+    String accessTokenValue = jwtProvider.createAccessToken(subject, tokenIdValue);
+    String refreshTokenValue = jwtProvider.createRefreshToken(subject, tokenIdValue);
+
+    Instant issuedAt = Instant.now();
+    return TokenPair.create(tokenIdValue, accessTokenValue, refreshTokenValue, subject, issuedAt);
+  }
+}

--- a/auth-service/src/main/java/shop/genieus/auth/infrastructure/support/token/util/AbstractJwtSupport.java
+++ b/auth-service/src/main/java/shop/genieus/auth/infrastructure/support/token/util/AbstractJwtSupport.java
@@ -1,0 +1,14 @@
+package shop.genieus.auth.infrastructure.support.token.util;
+
+import java.security.Key;
+import lombok.RequiredArgsConstructor;
+import shop.genieus.auth.global.config.JwtConfig;
+
+@RequiredArgsConstructor
+public abstract class AbstractJwtSupport {
+  protected final Key key;
+
+  public AbstractJwtSupport(JwtConfig jwtConfig) {
+    this.key = jwtConfig.getKey();
+  }
+}

--- a/auth-service/src/main/java/shop/genieus/auth/infrastructure/support/token/util/JwtProvider.java
+++ b/auth-service/src/main/java/shop/genieus/auth/infrastructure/support/token/util/JwtProvider.java
@@ -1,0 +1,52 @@
+package shop.genieus.auth.infrastructure.support.token.util;
+
+import io.jsonwebtoken.JwtBuilder;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Date;
+import lombok.NonNull;
+import org.springframework.stereotype.Component;
+import shop.genieus.auth.domain.model.vo.TokenType;
+import shop.genieus.auth.global.config.JwtConfig;
+
+@Component
+public class JwtProvider extends AbstractJwtSupport {
+  protected static final SignatureAlgorithm SIGNATURE_ALGORITHM = SignatureAlgorithm.HS256;
+
+  public JwtProvider(JwtConfig jwtConfig) {
+    super(jwtConfig);
+  }
+
+  public JwtBuilder createToken(Long subject, long expirationMs) {
+    Date now = new Date();
+    Date tokenExpiry = Date.from(Instant.now().plus(Duration.ofMillis(expirationMs)));
+
+    return Jwts.builder()
+        .setSubject(String.valueOf(subject))
+        .setIssuedAt(now)
+        .setExpiration(tokenExpiry)
+        .signWith(key, SIGNATURE_ALGORITHM);
+  }
+
+  public String createAccessToken(@NonNull Long subject, String jti) {
+    return this.createToken(subject, getAccessExpirationMs()).setId(jti).compact();
+  }
+
+  public String createRefreshToken(@NonNull Long subject, String jti) {
+    return this.createToken(subject, getRefreshTokenExpirationMs()).setId(jti).compact();
+  }
+
+  private long getAccessExpirationMs() {
+    return this.getAccessExpirationMs(TokenType.ACCESS);
+  }
+
+  private long getRefreshTokenExpirationMs() {
+    return this.getAccessExpirationMs(TokenType.REFRESH);
+  }
+
+  private long getAccessExpirationMs(TokenType type) {
+    return type.getExpiration().toMillis();
+  }
+}

--- a/auth-service/src/main/java/shop/genieus/auth/presentation/rest/controller/AuthController.java
+++ b/auth-service/src/main/java/shop/genieus/auth/presentation/rest/controller/AuthController.java
@@ -1,0 +1,32 @@
+package shop.genieus.auth.presentation.rest.controller;
+
+import com.genieus.common.response.ApiResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import shop.genieus.auth.application.in.command.AuthenticationCommandService;
+import shop.genieus.auth.application.in.command.dto.LoginCommand;
+import shop.genieus.auth.domain.model.TokenPair;
+import shop.genieus.auth.presentation.rest.dto.AuthApiResponse;
+import shop.genieus.auth.presentation.rest.dto.request.LoginRequest;
+import shop.genieus.auth.presentation.rest.dto.response.LoginResponse;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/auth")
+public class AuthController {
+  private final AuthenticationCommandService commandService;
+
+  @PostMapping("/login")
+  public ResponseEntity<ApiResponse<LoginResponse>> login(
+      @Valid @RequestBody final LoginRequest request) {
+    LoginCommand command = request.toCommand();
+    TokenPair tokenPair = commandService.login(command);
+
+    return ResponseEntity.ok().body(AuthApiResponse.ok(LoginResponse.from(tokenPair)));
+  }
+}

--- a/auth-service/src/main/java/shop/genieus/auth/presentation/rest/dto/AuthApiResponse.java
+++ b/auth-service/src/main/java/shop/genieus/auth/presentation/rest/dto/AuthApiResponse.java
@@ -1,0 +1,16 @@
+package shop.genieus.auth.presentation.rest.dto;
+
+import com.genieus.common.response.ApiResponse;
+
+public record AuthApiResponse<T>(String message, T data) {
+  private static final int AUTH_SERVICE_CODE = 7000;
+  private static final String DEFAULT_SUCCESS_MESSAGE = "응답이 성공적으로 완료되었습니다.";
+
+  public static <T> ApiResponse<T> of(String message, T data) {
+    return ApiResponse.of(AUTH_SERVICE_CODE, message, data);
+  }
+
+  public static <T> ApiResponse<T> ok(T data) {
+    return ApiResponse.of(AUTH_SERVICE_CODE, DEFAULT_SUCCESS_MESSAGE, data);
+  }
+}

--- a/auth-service/src/main/java/shop/genieus/auth/presentation/rest/dto/request/LoginRequest.java
+++ b/auth-service/src/main/java/shop/genieus/auth/presentation/rest/dto/request/LoginRequest.java
@@ -1,0 +1,12 @@
+package shop.genieus.auth.presentation.rest.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import shop.genieus.auth.application.in.command.dto.LoginCommand;
+
+public record LoginRequest(
+    @NotBlank(message = "아이디를 입력해주세요.") String username,
+    @NotBlank(message = "비밀번호를 입력해주세요.") String password) {
+  public LoginCommand toCommand() {
+    return new LoginCommand(username, password);
+  }
+}

--- a/auth-service/src/main/java/shop/genieus/auth/presentation/rest/dto/response/LoginResponse.java
+++ b/auth-service/src/main/java/shop/genieus/auth/presentation/rest/dto/response/LoginResponse.java
@@ -1,0 +1,11 @@
+package shop.genieus.auth.presentation.rest.dto.response;
+
+import shop.genieus.auth.domain.model.TokenPair;
+
+public record LoginResponse(String accessToken, String refreshToken) {
+  public static LoginResponse from(TokenPair tokenPair) {
+    return new LoginResponse(
+        tokenPair.getAccessTokenCredential().tokenValue(),
+        tokenPair.getRefreshTokenCredential().tokenValue());
+  }
+}

--- a/auth-service/src/main/resources/application-local.yml
+++ b/auth-service/src/main/resources/application-local.yml
@@ -29,3 +29,5 @@ management:
   tracing:
     sampling:
       probability: 1.0
+jwt:
+  secret: P7Vr8Fjz6Fv9UHs8jJ4wpb1v+3n2Fq0ZaVby/v4M8yQ=

--- a/auth-service/src/main/resources/redis/save-refresh-token.lua
+++ b/auth-service/src/main/resources/redis/save-refresh-token.lua
@@ -1,0 +1,8 @@
+-- 토큰 저장
+redis.call('SET', KEYS[1], ARGV[1], 'PX', ARGV[2])
+
+-- 사용자 ID와 토큰 ID 매핑 정보 저장 (Set 자료구조 사용)
+redis.call('SADD', KEYS[2], ARGV[3])
+redis.call('PEXPIRE', KEYS[2], ARGV[2])
+
+return 1

--- a/auth-service/src/main/resources/sql/create_auth_user.sql
+++ b/auth-service/src/main/resources/sql/create_auth_user.sql
@@ -1,0 +1,5 @@
+-- test user 생성: 이메일: test123@test.com, 비밀번호: Test!123, 권한: MASTER_ADMIN 조건의 로그인 유저 생성
+INSERT INTO m_auth_user (user_id, created_at, created_by, deleted_at, deleted_by, updated_at, updated_by, email,
+                         is_active, password, role)
+VALUES (1, '2025-04-08 22:28:02.000000', 1, null, null, null, null, 'test123@test.com', true,
+        '$2a$10$/OuXtJxHEg7aW6ocDRVzbuzxAs85cAzyqB5oGw19Xw2nRshLjXk8u', 'MASTER_ADMIN');


### PR DESCRIPTION
## 개요
인증 서비스에 JWT 기반 로그인 기능을 구현하였습니다. 사용자 인증, 토큰 발급 및 관리를 위한 전체 흐름을 구현했습니다.

## 📝 작업 내용
### 변경 사항
- 사용자 로그인 API 엔드포인트 (`/api/v1/auth/login`) 구현
- JWT 기반 토큰 생성 및 관리 시스템 구현
- Redis를 활용한 토큰 저장소 구현
- 테스트용 관리자 계정 생성 SQL 스크립트 추가(`resources/sql/create_auth_user.sql`)

### 변경 이유
- 사용자 인증 시스템을 구축하여 보안성 강화
- JWT 표준을 채택하여 상태 비저장(stateless) 인증 구현
  - 짧은 ttl을 가진 access token, 상대적으로 긴 refresh token 발급(서버에 저장)

### 추가 설명
**토큰 관리 정책:**
1. **토큰 구조**
   - 액세스 토큰과 리프레시 토큰으로 구성된 TokenPair 발급
   - 두 토큰 모두 동일한 고유 ID(jti)를 공유하여 쌍으로 관리
   - 토큰 유형별 만료 시간 설정:
     ```java
     @Getter
     public enum TokenType {
       ACCESS(Duration.ofMinutes(15)),
       REFRESH(Duration.ofDays(7));
     ```

2. **토큰 저장**
   - 리프레시 토큰만 서버(Redis)에 저장: 이후 리프레시 토큰 재발급 요청 시 검증용으로 사용하기 위함이며, 상대적으로 긴 유효 기간 부여
   - Redis에 두 개의 키-값 쌍으로 저장:
     - `refresh:token:{tokenId}`: 리프레시 토큰 값 저장
       - 이 형식으로 저장하는 이유: 리프레시 토큰 재발급 요청 시, JWT 토큰에서 추출한 토큰 ID(jti)로 검증 가능
       - JWT 서명이 유효하더라도 서버에서 폐기된 토큰은 사용 불가능하게 하는 이중 검증 방식
     - `user:tokens:{userId}`: 사용자별 토큰 ID 목록을 Set으로 저장
   - Lua 스크립트로 원자적 작업 보장: 여러 Redis 명령어를 단일 트랜잭션으로 처리하여 토큰 저장에 두 번의 연결을 하지 않아 성능 향상 및 데이터 일관성 확보

3. **Set 자료구조 활용 이유**
   - **유저 단위 일괄 토큰 관리**: 한 사용자의 모든 리프레시 토큰을 효율적으로 관리
   - **보안 강화**: 로그아웃이나 계정 탈퇴 시 모든 기기에서 세션 일괄 만료 가능
   - **다중 디바이스 지원**: 여러 기기에서 로그인한 경우에도 일관된 관리 가능
   - **로그아웃 구현 용이**: 특정 세션만 종료하거나 전체 세션 종료 기능 구현 편리
   - 향후 구현 예정인 로그아웃 시:
     ```java
     redisTemplate.opsForSet().remove("user:tokens:" + userId, tokenId);
     redisTemplate.delete("refresh:token:" + tokenId); // 명시적 만료
     ```

4. **로그인 인증 흐름**
<img width="787" alt="image" src="https://github.com/user-attachments/assets/280279bf-fc1d-45eb-be6c-b0b9477f2152" />


## 💬리뷰 요구사항
- 토큰 관리 정책이 적절한지 검토 부탁드립니다
- Redis 저장 방식에 대한 의견 있으시면 말씀해주세요
- 추후 로그아웃 기능과 토큰 갱신 엔드포인트 구현 계획 있습니다

#### #️⃣ 연관된 이슈
closed #12

## PR 유형
이 PR은 어떤 변경 사항을 포함하고 있나요?
- [x] 새로운 기능 추가
- [x] 빌드 부분 혹은 패키지 매니저 수정

## ✅ Check List
PR이 다음 요구 사항을 충족하는지 확인하세요.
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다. (버그 수정/기능에 대한 테스트)
- [ ] CI/CD 파이프라인을 통과했습니다.