### PR TITLE
[Feat] 리프레쉬 토큰 재발급 요청 기능 구현

### DIFF
--- a/auth-service/src/main/java/shop/genieus/auth/application/in/command/AuthenticationCommandService.java
+++ b/auth-service/src/main/java/shop/genieus/auth/application/in/command/AuthenticationCommandService.java
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import shop.genieus.auth.application.in.command.dto.LoginCommand;
 import shop.genieus.auth.application.in.command.dto.LogoutCommand;
+import shop.genieus.auth.application.in.command.dto.RefreshCommand;
 import shop.genieus.auth.application.out.persistence.AuthPersistencePort;
 import shop.genieus.auth.application.out.support.encoder.PasswordEncryptionPort;
 import shop.genieus.auth.application.out.support.id.IdGeneratorPort;
@@ -50,6 +51,22 @@ public class AuthenticationCommandService {
     log.info("로그아웃 성공: TokenId={}", tokenId.value());
   }
 
+  public TokenPair refresh(final RefreshCommand command) {
+    String refreshToken = command.refreshToken();
+    TokenValidationResult validationResult = tokenPort.validateTokenAndExtractId(command.refreshToken());
+
+    Long userId = validationResult.getUserId();
+    TokenId oldTokenId = validationResult.getTokenId();
+
+    validateRefreshToken(oldTokenId, refreshToken);
+    invalidateOldTokenIfNeeded(command.accessToken(), oldTokenId, userId);
+
+    TokenPair newTokenPair = createAndSaveTokenPair(userId);
+    log.info("토큰 갱신 성공- Id: {}", userId);
+
+    return newTokenPair;
+  }
+
   private TokenPair createAndSaveTokenPair(Long userId) {
     String tokenId = idGenerator.generateUniqueId();
     TokenPair tokenPair = tokenPort.createTokenPair(tokenId, userId);
@@ -72,5 +89,12 @@ public class AuthenticationCommandService {
       throw new IllegalArgumentException("차단된 JWT 토큰입니다.");
     }
     return tokenValidationResult;
+  }
+
+  private void validateRefreshToken(TokenId tokenId, String refreshToken) {
+    boolean isValidRefreshToken = persistencePort.isValidRefreshToken(tokenId, refreshToken);
+    if (!isValidRefreshToken) {
+      throw new IllegalArgumentException("저장된 리프레시 토큰과 일치하지 않습니다. 다시 로그인해주세요.");
+    }
   }
 }

--- a/auth-service/src/main/java/shop/genieus/auth/application/in/command/AuthenticationCommandService.java
+++ b/auth-service/src/main/java/shop/genieus/auth/application/in/command/AuthenticationCommandService.java
@@ -37,17 +37,17 @@ public class AuthenticationCommandService {
       throw new IllegalArgumentException("입력하신 아이디 또는 비밀번호가 잘못되었습니다.");
     }
 
-    TokenPair tokenPair = createAndSaveTokenPair(user.getId());
+    TokenPair tokenPair = generateAndPersistTokenPair(user.getId());
     log.info("로그인 성공, 유저 로그인 아이디: {}", user.getEmail());
 
     return tokenPair;
   }
 
   public void logout(final LogoutCommand command) {
-    TokenValidationResult tokenValidationResult = validateAndCheckBlacklist(command.accessToken());
+    TokenValidationResult tokenValidationResult = validateTokenAndCheckBlacklist(command.accessToken());
 
     TokenId tokenId = tokenValidationResult.getTokenId();
-    invalidateOldTokenIfNeeded(command.accessToken(), tokenId, tokenValidationResult.getUserId());
+    revokeTokenPair(command.accessToken(), tokenId, tokenValidationResult.getUserId());
     log.info("로그아웃 성공: TokenId={}", tokenId.value());
   }
 
@@ -59,15 +59,15 @@ public class AuthenticationCommandService {
     TokenId oldTokenId = validationResult.getTokenId();
 
     validateRefreshToken(oldTokenId, refreshToken);
-    invalidateOldTokenIfNeeded(command.accessToken(), oldTokenId, userId);
+    revokeTokenPair(command.accessToken(), oldTokenId, userId);
 
-    TokenPair newTokenPair = createAndSaveTokenPair(userId);
+    TokenPair newTokenPair = generateAndPersistTokenPair(userId);
     log.info("토큰 갱신 성공- Id: {}", userId);
 
     return newTokenPair;
   }
 
-  private TokenPair createAndSaveTokenPair(Long userId) {
+  private TokenPair generateAndPersistTokenPair(Long userId) {
     String tokenId = idGenerator.generateUniqueId();
     TokenPair tokenPair = tokenPort.createTokenPair(tokenId, userId);
     persistencePort.saveRefreshToken(
@@ -75,7 +75,7 @@ public class AuthenticationCommandService {
     return tokenPair;
   }
 
-  private void invalidateOldTokenIfNeeded(String accessToken, TokenId tokenId, Long userId) {
+  private void revokeTokenPair(String accessToken, TokenId tokenId, Long userId) {
     Instant expirationTime = tokenPort.getExpirationTime(accessToken);
     if (expirationTime.isAfter(Instant.now())) {
       persistencePort.addToBlacklist(tokenId, expirationTime);
@@ -83,7 +83,7 @@ public class AuthenticationCommandService {
     persistencePort.removeRefreshToken(tokenId, userId);
   }
 
-  private TokenValidationResult validateAndCheckBlacklist(String token) {
+  private TokenValidationResult validateTokenAndCheckBlacklist(String token) {
     TokenValidationResult tokenValidationResult = tokenPort.validateTokenAndExtractId(token);
     if (persistencePort.isBlacklisted(tokenValidationResult.getTokenId())) {
       throw new IllegalArgumentException("차단된 JWT 토큰입니다.");

--- a/auth-service/src/main/java/shop/genieus/auth/application/in/command/dto/RefreshCommand.java
+++ b/auth-service/src/main/java/shop/genieus/auth/application/in/command/dto/RefreshCommand.java
@@ -1,0 +1,3 @@
+package shop.genieus.auth.application.in.command.dto;
+
+public record RefreshCommand(String accessToken, String refreshToken) {}

--- a/auth-service/src/main/java/shop/genieus/auth/application/out/persistence/AuthPersistencePort.java
+++ b/auth-service/src/main/java/shop/genieus/auth/application/out/persistence/AuthPersistencePort.java
@@ -15,4 +15,6 @@ public interface AuthPersistencePort {
   void removeRefreshToken(TokenId tokenId, Long userId);
 
   boolean isBlacklisted(TokenId tokenId);
+
+  boolean isValidRefreshToken(TokenId tokenId, String refreshToken);
 }

--- a/auth-service/src/main/java/shop/genieus/auth/infrastructure/persistence/AuthPersistenceAdapter.java
+++ b/auth-service/src/main/java/shop/genieus/auth/infrastructure/persistence/AuthPersistenceAdapter.java
@@ -55,4 +55,14 @@ public class AuthPersistenceAdapter implements AuthPersistencePort {
   public boolean isBlacklisted(TokenId tokenId) {
     return tokenRedisRepository.isBlacklisted(tokenId.value());
   }
+
+  @Override
+  public boolean isValidRefreshToken(TokenId userId, String refreshToken) {
+    if (userId == null || refreshToken == null || refreshToken.isEmpty()) {
+      return false;
+    }
+    String storedToken = tokenRedisRepository.getRefreshToken(userId.value());
+
+    return storedToken != null && storedToken.equals(refreshToken);
+  }
 }

--- a/auth-service/src/main/java/shop/genieus/auth/infrastructure/persistence/repository/TokenRedisRepository.java
+++ b/auth-service/src/main/java/shop/genieus/auth/infrastructure/persistence/repository/TokenRedisRepository.java
@@ -47,4 +47,9 @@ public class TokenRedisRepository {
     String key = BLACKLIST_PREFIX + tokenId;
     return Boolean.TRUE.equals(redisTemplate.hasKey(key));
   }
+
+  public String getRefreshToken(String tokenId) {
+    String key = REFRESH_TOKEN_PREFIX + tokenId;
+    return redisTemplate.opsForValue().get(key);
+  }
 }

--- a/auth-service/src/main/java/shop/genieus/auth/presentation/rest/controller/AuthController.java
+++ b/auth-service/src/main/java/shop/genieus/auth/presentation/rest/controller/AuthController.java
@@ -11,12 +11,15 @@ import org.springframework.web.bind.annotation.RestController;
 import shop.genieus.auth.application.in.command.AuthenticationCommandService;
 import shop.genieus.auth.application.in.command.dto.LoginCommand;
 import shop.genieus.auth.application.in.command.dto.LogoutCommand;
+import shop.genieus.auth.application.in.command.dto.RefreshCommand;
 import shop.genieus.auth.domain.model.TokenPair;
 import shop.genieus.auth.presentation.rest.dto.AuthApiResponse;
 import shop.genieus.auth.presentation.rest.dto.request.LoginRequest;
 import shop.genieus.auth.presentation.rest.dto.request.LogoutRequest;
+import shop.genieus.auth.presentation.rest.dto.request.RefreshTokenRequest;
 import shop.genieus.auth.presentation.rest.dto.response.LoginResponse;
 import shop.genieus.auth.presentation.rest.dto.response.LogoutResponse;
+import shop.genieus.auth.presentation.rest.dto.response.RefreshTokenResponse;
 
 @RestController
 @RequiredArgsConstructor
@@ -40,5 +43,14 @@ public class AuthController {
     commandService.logout(command);
 
     return ResponseEntity.ok().body(AuthApiResponse.ok(LogoutResponse.success()));
+  }
+
+  @PostMapping("/refresh")
+  public ResponseEntity<ApiResponse<RefreshTokenResponse>> refreshToken(
+      @Valid @RequestBody final RefreshTokenRequest request) {
+    RefreshCommand command = request.toCommand(request);
+    TokenPair tokenPair = commandService.refresh(command);
+
+    return ResponseEntity.ok().body(AuthApiResponse.ok(RefreshTokenResponse.from(tokenPair)));
   }
 }

--- a/auth-service/src/main/java/shop/genieus/auth/presentation/rest/dto/request/RefreshTokenRequest.java
+++ b/auth-service/src/main/java/shop/genieus/auth/presentation/rest/dto/request/RefreshTokenRequest.java
@@ -1,0 +1,13 @@
+package shop.genieus.auth.presentation.rest.dto.request;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import shop.genieus.auth.application.in.command.dto.RefreshCommand;
+
+public record RefreshTokenRequest(
+    @NotBlank(message = "액세스 토큰이 필요합니다.") String accessToken,
+    @NotBlank(message = "리프레쉬 토큰이 필요합니다.") String refreshToken) {
+  public RefreshCommand toCommand(@Valid RefreshTokenRequest request) {
+    return new RefreshCommand(accessToken, refreshToken);
+  }
+}

--- a/auth-service/src/main/java/shop/genieus/auth/presentation/rest/dto/response/RefreshTokenResponse.java
+++ b/auth-service/src/main/java/shop/genieus/auth/presentation/rest/dto/response/RefreshTokenResponse.java
@@ -1,0 +1,11 @@
+package shop.genieus.auth.presentation.rest.dto.response;
+
+import shop.genieus.auth.domain.model.TokenPair;
+
+public record RefreshTokenResponse(String accessToken, String refreshToken) {
+  public static RefreshTokenResponse from(TokenPair tokenPair) {
+    return new RefreshTokenResponse(
+        tokenPair.getAccessTokenCredential().tokenValue(),
+        tokenPair.getRefreshTokenCredential().tokenValue());
+  }
+}


### PR DESCRIPTION
## 개요
인증 서비스에 토큰 재발급 기능을 구현하여 액세스 토큰 만료 시 사용자가 리프레시 토큰을 통해 새로운 토큰 페어를 발급받을 수 있도록 했습니다. 

## 📝 작업 내용

### 변경 사항
- 토큰 재발급 API 엔드포인트 (`/api/v1/auth/refresh`) 구현
- 리프레시 토큰 검증 로직 추가
- 기존 토큰 무효화 및 새 토큰 발급 프로세스 구현

### 변경 이유
- 액세스 토큰 만료 시 재로그인 없이 인증 상태 유지
- 짧은 수명의 액세스 토큰과 긴 수명의 리프레시 토큰 분리 관리
- 기존 리프레시 토큰 무효화를 통한 토큰 재사용 방지

### 추가 설명

**토큰 재발급 정책:**

1. **리프레시 토큰 검증**
    - JWT 서명 및 만료 여부 검증
    - Redis에 저장된 리프레시 토큰과 요청된 토큰의 일치 여부 확인
2. **기존 토큰 무효화**
    - 기존 액세스 토큰을 블랙리스트에 추가하여 즉시 무효화
    - 기존 리프레시 토큰 삭제 및 사용자-토큰 매핑 제거
3. **새 토큰 발급**
    - 동일한 사용자 ID로 새로운 토큰 페어 생성
    - 새 리프레시 토큰을 Redis에 저장하고 사용자-토큰 매핑 업데이트
4. **토큰 재발급 흐름**
<img width="919" alt="image" src="https://github.com/user-attachments/assets/ea0aee0e-d2a3-4f73-8160-f3c3740221d1" />

### 💬리뷰 요구사항

#️⃣ 연관된 이슈
closed #16

## PR 유형
이 PR은 어떤 변경 사항을 포함하고 있나요?

- [x]  새로운 기능 추가

## ✅ Check List

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x]  커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x]  변경 사항에 대한 테스트를 했습니다. (버그 수정/기능에 대한 테스트)
- [x]  CI/CD 파이프라인을 통과했습니다.