### PR TITLE
[Feat] Auth Service, 내부 API 인증 및 패스포트 발급 기능 구현

### DIFF
--- a/auth-service/src/main/java/shop/genieus/auth/application/in/command/AuthenticationCommandService.java
+++ b/auth-service/src/main/java/shop/genieus/auth/application/in/command/AuthenticationCommandService.java
@@ -8,6 +8,7 @@ import org.springframework.transaction.annotation.Transactional;
 import shop.genieus.auth.application.in.command.dto.LoginCommand;
 import shop.genieus.auth.application.in.command.dto.LogoutCommand;
 import shop.genieus.auth.application.in.command.dto.RefreshCommand;
+import shop.genieus.auth.application.in.command.dto.ValidateAccessTokenCommand;
 import shop.genieus.auth.application.out.persistence.AuthPersistencePort;
 import shop.genieus.auth.application.out.support.encoder.PasswordEncryptionPort;
 import shop.genieus.auth.application.out.support.id.IdGeneratorPort;
@@ -44,7 +45,8 @@ public class AuthenticationCommandService {
   }
 
   public void logout(final LogoutCommand command) {
-    TokenValidationResult tokenValidationResult = validateTokenAndCheckBlacklist(command.accessToken());
+    TokenValidationResult tokenValidationResult =
+        validateTokenAndCheckBlacklist(command.accessToken());
 
     TokenId tokenId = tokenValidationResult.getTokenId();
     revokeTokenPair(command.accessToken(), tokenId, tokenValidationResult.getUserId());
@@ -53,7 +55,8 @@ public class AuthenticationCommandService {
 
   public TokenPair refresh(final RefreshCommand command) {
     String refreshToken = command.refreshToken();
-    TokenValidationResult validationResult = tokenPort.validateTokenAndExtractId(command.refreshToken());
+    TokenValidationResult validationResult =
+        tokenPort.validateTokenAndExtractId(command.refreshToken());
 
     Long userId = validationResult.getUserId();
     TokenId oldTokenId = validationResult.getTokenId();
@@ -65,6 +68,10 @@ public class AuthenticationCommandService {
     log.info("토큰 갱신 성공- Id: {}", userId);
 
     return newTokenPair;
+  }
+
+  public TokenValidationResult validateAccessToken(ValidateAccessTokenCommand command) {
+    return validateTokenAndCheckBlacklist(command.token());
   }
 
   private TokenPair generateAndPersistTokenPair(Long userId) {

--- a/auth-service/src/main/java/shop/genieus/auth/application/in/command/PassportCommandService.java
+++ b/auth-service/src/main/java/shop/genieus/auth/application/in/command/PassportCommandService.java
@@ -1,0 +1,63 @@
+package shop.genieus.auth.application.in.command;
+
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import shop.genieus.auth.application.in.command.dto.IssuePassportCommand;
+import shop.genieus.auth.application.out.persistence.AuthPersistencePort;
+import shop.genieus.auth.application.out.support.encoder.PassportEncodingPort;
+import shop.genieus.auth.application.out.support.id.IdGeneratorPort;
+import shop.genieus.auth.domain.model.Passport;
+import shop.genieus.auth.domain.model.entity.User;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+@Slf4j(topic = "[PassportCommandService]")
+public class PassportCommandService {
+  private final PassportEncodingPort passportEncodingPort;
+  private final AuthPersistencePort persistencePort;
+  private final IdGeneratorPort idGeneratorPort;
+
+  public String issueEncodedPassport(IssuePassportCommand command) {
+    Long userId = command.userId();
+
+    Passport cachedPassport = checkCachedPassport(userId);
+    if (cachedPassport != null) {
+      return serializePassport(cachedPassport);
+    }
+
+    User user = persistencePort.findByUserId(userId);
+    log.debug("passport 발급을 요청한 유저: {}", user.toString());
+    Passport passport = createAndSavePassport(user);
+
+    log.info("사용자 Id-[{}]에 대한 패스포트가 성공적으로 발급되었습니다.", userId);
+    return serializePassport(passport);
+  }
+
+  private Passport checkCachedPassport(Long userId) {
+    try {
+      Passport cachedPassport = persistencePort.findPassportFromCache(userId);
+      if (cachedPassport != null) {
+        return cachedPassport;
+      }
+    } catch (Exception exception) {
+      log.error(exception.getMessage());
+    }
+    return null;
+  }
+
+  private Passport createAndSavePassport(User user) {
+    String sessionId = idGeneratorPort.generateUniqueId();
+    LocalDateTime now = LocalDateTime.now();
+    Passport passport = Passport.create(sessionId, user.getId(), user.getRole().getValue(), now);
+
+    return persistencePort.savePassport(passport);
+  }
+
+  private String serializePassport(Passport passport) {
+    return passportEncodingPort.encode(passport);
+  }
+}

--- a/auth-service/src/main/java/shop/genieus/auth/application/in/command/dto/IssuePassportCommand.java
+++ b/auth-service/src/main/java/shop/genieus/auth/application/in/command/dto/IssuePassportCommand.java
@@ -1,0 +1,11 @@
+package shop.genieus.auth.application.in.command.dto;
+
+import shop.genieus.auth.domain.model.TokenValidationResult;
+import shop.genieus.auth.domain.model.vo.TokenId;
+
+public record IssuePassportCommand(TokenId tokenId, Long userId) {
+  public static IssuePassportCommand from(TokenValidationResult tokenValidationResult) {
+    return new IssuePassportCommand(
+        tokenValidationResult.getTokenId(), tokenValidationResult.getUserId());
+  }
+}

--- a/auth-service/src/main/java/shop/genieus/auth/application/in/command/dto/ValidateAccessTokenCommand.java
+++ b/auth-service/src/main/java/shop/genieus/auth/application/in/command/dto/ValidateAccessTokenCommand.java
@@ -1,0 +1,3 @@
+package shop.genieus.auth.application.in.command.dto;
+
+public record ValidateAccessTokenCommand(String token, String method, String uri) {}

--- a/auth-service/src/main/java/shop/genieus/auth/application/out/persistence/AuthPersistencePort.java
+++ b/auth-service/src/main/java/shop/genieus/auth/application/out/persistence/AuthPersistencePort.java
@@ -1,6 +1,7 @@
 package shop.genieus.auth.application.out.persistence;
 
 import java.time.Instant;
+import shop.genieus.auth.domain.model.Passport;
 import shop.genieus.auth.domain.model.entity.User;
 import shop.genieus.auth.domain.model.vo.TokenCredential;
 import shop.genieus.auth.domain.model.vo.TokenId;
@@ -17,4 +18,10 @@ public interface AuthPersistencePort {
   boolean isBlacklisted(TokenId tokenId);
 
   boolean isValidRefreshToken(TokenId tokenId, String refreshToken);
+
+  User findByUserId(Long userId);
+
+  Passport findPassportFromCache(Long userId);
+
+  Passport savePassport(Passport passport);
 }

--- a/auth-service/src/main/java/shop/genieus/auth/application/out/support/encoder/PassportEncodingPort.java
+++ b/auth-service/src/main/java/shop/genieus/auth/application/out/support/encoder/PassportEncodingPort.java
@@ -1,0 +1,7 @@
+package shop.genieus.auth.application.out.support.encoder;
+
+import shop.genieus.auth.domain.model.Passport;
+
+public interface PassportEncodingPort {
+  String encode(Passport passport);
+}

--- a/auth-service/src/main/java/shop/genieus/auth/domain/model/vo/Email.java
+++ b/auth-service/src/main/java/shop/genieus/auth/domain/model/vo/Email.java
@@ -3,9 +3,11 @@ package shop.genieus.auth.domain.model.vo;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 import shop.genieus.auth.global.common.AbstractEmail;
 
+@Getter
 @Embeddable
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Email extends AbstractEmail {

--- a/auth-service/src/main/java/shop/genieus/auth/domain/model/vo/Role.java
+++ b/auth-service/src/main/java/shop/genieus/auth/domain/model/vo/Role.java
@@ -5,10 +5,12 @@ import jakarta.persistence.Embeddable;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 import shop.genieus.auth.global.common.AbstractRole;
 import shop.genieus.auth.global.common.RoleType;
 
+@Getter
 @Embeddable
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Role extends AbstractRole {

--- a/auth-service/src/main/java/shop/genieus/auth/global/common/AuthClientResponse.java
+++ b/auth-service/src/main/java/shop/genieus/auth/global/common/AuthClientResponse.java
@@ -1,0 +1,13 @@
+package shop.genieus.auth.global.common;
+
+import com.genieus.common.passport.constant.PassportConstant;
+
+public record AuthClientResponse(String encodedPassport, String passportHeaderKey) {
+  public static AuthClientResponse from(String encodedPassport, String passportHeaderKey) {
+    return new AuthClientResponse(encodedPassport, passportHeaderKey);
+  }
+
+  public static AuthClientResponse from(String encodedPassport) {
+    return AuthClientResponse.from(encodedPassport, PassportConstant.PASSPORT_HEADER);
+  }
+}

--- a/auth-service/src/main/java/shop/genieus/auth/global/config/PassportEncodingConfig.java
+++ b/auth-service/src/main/java/shop/genieus/auth/global/config/PassportEncodingConfig.java
@@ -1,0 +1,18 @@
+package shop.genieus.auth.global.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.genieus.common.passport.util.PassportUtils;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@RequiredArgsConstructor
+public class PassportEncodingConfig {
+  private final ObjectMapper objectMapper;
+
+  @Bean
+  public PassportUtils passportUtils() {
+    return new PassportUtils(objectMapper);
+  }
+}

--- a/auth-service/src/main/java/shop/genieus/auth/infrastructure/persistence/AuthPersistenceAdapter.java
+++ b/auth-service/src/main/java/shop/genieus/auth/infrastructure/persistence/AuthPersistenceAdapter.java
@@ -5,10 +5,12 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import shop.genieus.auth.application.out.persistence.AuthPersistencePort;
+import shop.genieus.auth.domain.model.Passport;
 import shop.genieus.auth.domain.model.entity.User;
 import shop.genieus.auth.domain.model.vo.Email;
 import shop.genieus.auth.domain.model.vo.TokenCredential;
 import shop.genieus.auth.domain.model.vo.TokenId;
+import shop.genieus.auth.infrastructure.persistence.repository.PassportRedisRepository;
 import shop.genieus.auth.infrastructure.persistence.repository.TokenRedisRepository;
 import shop.genieus.auth.infrastructure.persistence.repository.UserJpaRepository;
 
@@ -18,6 +20,7 @@ import shop.genieus.auth.infrastructure.persistence.repository.UserJpaRepository
 public class AuthPersistenceAdapter implements AuthPersistencePort {
   private final UserJpaRepository userJpaRepository;
   private final TokenRedisRepository tokenRedisRepository;
+  private final PassportRedisRepository passportRedisRepository;
 
   @Override
   public User findByEmail(String username) {
@@ -64,5 +67,27 @@ public class AuthPersistenceAdapter implements AuthPersistencePort {
     String storedToken = tokenRedisRepository.getRefreshToken(userId.value());
 
     return storedToken != null && storedToken.equals(refreshToken);
+  }
+
+  @Override
+  public User findByUserId(Long userId) {
+    return userJpaRepository
+        .findByIdNotDeleted(userId)
+        .orElseThrow(() -> new IllegalArgumentException("회원이 존재하지 않습니다."));
+  }
+
+  @Override
+  public Passport findPassportFromCache(Long userId) {
+    try {
+      Passport passport = passportRedisRepository.findPassportByUserId(userId);
+      return passport;
+    } catch (Exception exception) {
+      throw exception;
+    }
+  }
+
+  @Override
+  public Passport savePassport(Passport passport) {
+    return passportRedisRepository.savePassport(passport);
   }
 }

--- a/auth-service/src/main/java/shop/genieus/auth/infrastructure/persistence/repository/PassportRedisRepository.java
+++ b/auth-service/src/main/java/shop/genieus/auth/infrastructure/persistence/repository/PassportRedisRepository.java
@@ -1,0 +1,70 @@
+package shop.genieus.auth.infrastructure.persistence.repository;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Arrays;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Repository;
+import shop.genieus.auth.domain.model.Passport;
+import shop.genieus.auth.infrastructure.persistence.util.LuaScriptProvider;
+
+@Repository
+@RequiredArgsConstructor
+public class PassportRedisRepository {
+  private static final String PASSPORT_PREFIX = "passport:";
+  private static final String USER_PASSPORT_PREFIX = "user:passport:";
+
+  private final StringRedisTemplate redisTemplate;
+  private final ObjectMapper objectMapper;
+
+  public Passport savePassport(Passport passport) {
+    try {
+      String passportKey = PASSPORT_PREFIX + passport.getSessionId();
+      String userPassportKey = USER_PASSPORT_PREFIX + passport.getUserId();
+
+      List<String> keys = Arrays.asList(passportKey, userPassportKey);
+
+      String passportJson = objectMapper.writeValueAsString(passport);
+      long ttlMillis = calculateTtlMillis(passport.getExpiresAt());
+
+      redisTemplate.execute(
+          LuaScriptProvider.getSavePassportScript(),
+          keys,
+          passportJson,
+          String.valueOf(ttlMillis),
+          passport.getSessionId());
+
+      return passport;
+    } catch (JsonProcessingException e) {
+      throw new IllegalArgumentException(
+          "Passport 캐싱 실패- passport: %s, message: %s"
+              .formatted(passport.toString(), e.getMessage()));
+    }
+  }
+
+  public Passport findPassportByUserId(Long userId) {
+    String userPassportKey = USER_PASSPORT_PREFIX + userId;
+    List<String> keys = Arrays.asList(userPassportKey, PASSPORT_PREFIX);
+
+    String passportJson =
+        redisTemplate.execute(LuaScriptProvider.getFindPassportByUserIdScript(), keys);
+    if (passportJson == null) return null;
+
+    try {
+      return objectMapper.readValue(passportJson, Passport.class);
+    } catch (JsonProcessingException e) {
+      throw new IllegalArgumentException(
+          "Passport 파싱 실패- userId: %s, message: %s".formatted(userId, e.getMessage()));
+    }
+  }
+
+  private long calculateTtlMillis(LocalDateTime expiresAt) {
+    long expiresAtMillis = expiresAt.atZone(ZoneId.systemDefault()).toInstant().toEpochMilli();
+    long nowMillis = System.currentTimeMillis();
+    return Math.max(0, expiresAtMillis - nowMillis);
+  }
+}

--- a/auth-service/src/main/java/shop/genieus/auth/infrastructure/persistence/repository/UserJpaRepository.java
+++ b/auth-service/src/main/java/shop/genieus/auth/infrastructure/persistence/repository/UserJpaRepository.java
@@ -10,4 +10,7 @@ import shop.genieus.auth.domain.model.vo.Email;
 public interface UserJpaRepository extends JpaRepository<User, String> {
   @Query("SELECT u FROM User u WHERE u.email = :email AND u.deletedAt IS NULL")
   Optional<User> findByEmailNotDeleted(@Param("email") Email email);
+
+  @Query("SELECT u FROM User u WHERE u.id = :id AND u.deletedAt IS NULL")
+  Optional<User> findByIdNotDeleted(@Param("id") Long userId);
 }

--- a/auth-service/src/main/java/shop/genieus/auth/infrastructure/persistence/util/LuaScriptProvider.java
+++ b/auth-service/src/main/java/shop/genieus/auth/infrastructure/persistence/util/LuaScriptProvider.java
@@ -8,16 +8,38 @@ import org.springframework.scripting.support.ResourceScriptSource;
 public class LuaScriptProvider {
 
   private static final RedisScript<Long> SAVE_REFRESH_TOKEN_SCRIPT;
+  private static final RedisScript<Long> SAVE_PASSPORT_SCRIPT;
+  private static final RedisScript<String> FIND_PASSPORT_BY_USER_ID_SCRIPT;
 
   static {
-    DefaultRedisScript<Long> script = new DefaultRedisScript<>();
-    script.setScriptSource(
+    DefaultRedisScript<Long> refreshTokenScript = new DefaultRedisScript<>();
+    refreshTokenScript.setScriptSource(
         new ResourceScriptSource(new ClassPathResource("redis/save-refresh-token.lua")));
-    script.setResultType(Long.class);
-    SAVE_REFRESH_TOKEN_SCRIPT = script;
+    refreshTokenScript.setResultType(Long.class);
+    SAVE_REFRESH_TOKEN_SCRIPT = refreshTokenScript;
+
+    DefaultRedisScript<Long> passportScript = new DefaultRedisScript<>();
+    passportScript.setScriptSource(
+        new ResourceScriptSource(new ClassPathResource("redis/save-passport.lua")));
+    passportScript.setResultType(Long.class);
+    SAVE_PASSPORT_SCRIPT = passportScript;
+
+    DefaultRedisScript<String> findPassportByUserIdScript = new DefaultRedisScript<>();
+    findPassportByUserIdScript.setScriptSource(
+        new ResourceScriptSource(new ClassPathResource("redis/find-passport-by-user-id.lua")));
+    findPassportByUserIdScript.setResultType(String.class);
+    FIND_PASSPORT_BY_USER_ID_SCRIPT = findPassportByUserIdScript;
   }
 
   public static RedisScript<Long> getSaveRefreshTokenScript() {
     return SAVE_REFRESH_TOKEN_SCRIPT;
+  }
+
+  public static RedisScript<Long> getSavePassportScript() {
+    return SAVE_PASSPORT_SCRIPT;
+  }
+
+  public static RedisScript<String> getFindPassportByUserIdScript() {
+    return FIND_PASSPORT_BY_USER_ID_SCRIPT;
   }
 }

--- a/auth-service/src/main/java/shop/genieus/auth/infrastructure/support/encoder/Base64PassportEncodingAdapter.java
+++ b/auth-service/src/main/java/shop/genieus/auth/infrastructure/support/encoder/Base64PassportEncodingAdapter.java
@@ -1,0 +1,23 @@
+package shop.genieus.auth.infrastructure.support.encoder;
+
+import com.genieus.common.passport.model.Passport;
+import com.genieus.common.passport.model.RoleType;
+import com.genieus.common.passport.util.PassportUtils;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import shop.genieus.auth.application.out.support.encoder.PassportEncodingPort;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j(topic = "Base64PassportEncodingAdapter")
+public class Base64PassportEncodingAdapter implements PassportEncodingPort {
+  private final PassportUtils passportUtils;
+
+  @Override
+  public String encode(shop.genieus.auth.domain.model.Passport domainPassport) {
+    Passport passport =
+        new Passport(domainPassport.getUserId(), /*domainPassport.getRole()*/ RoleType.ADMIN);
+    return passportUtils.encode(passport);
+  }
+}

--- a/auth-service/src/main/java/shop/genieus/auth/presentation/rest/controller/AuthInternalController.java
+++ b/auth-service/src/main/java/shop/genieus/auth/presentation/rest/controller/AuthInternalController.java
@@ -1,0 +1,37 @@
+package shop.genieus.auth.presentation.rest.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import shop.genieus.auth.application.in.command.AuthenticationCommandService;
+import shop.genieus.auth.application.in.command.PassportCommandService;
+import shop.genieus.auth.application.in.command.dto.IssuePassportCommand;
+import shop.genieus.auth.application.in.command.dto.ValidateAccessTokenCommand;
+import shop.genieus.auth.domain.model.TokenValidationResult;
+import shop.genieus.auth.global.common.AuthClientResponse;
+import shop.genieus.auth.presentation.rest.dto.request.AuthClientRequest;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/internal/v1/auth")
+public class AuthInternalController {
+  private final AuthenticationCommandService authenticationCommandService;
+  private final PassportCommandService passportCommandService;
+
+  @PostMapping("/passport")
+  public ResponseEntity<AuthClientResponse> issueEncodedPassport(
+      @RequestBody final AuthClientRequest request) {
+    TokenValidationResult authenticationResult =
+        authenticationCommandService.validateAccessToken(
+            new ValidateAccessTokenCommand(request.token(), request.method(), request.uri()));
+
+    String serializePassport =
+        passportCommandService.issueEncodedPassport(
+            IssuePassportCommand.from(authenticationResult));
+
+    return ResponseEntity.ok().body(AuthClientResponse.from(serializePassport));
+  }
+}

--- a/auth-service/src/main/java/shop/genieus/auth/presentation/rest/dto/request/AuthClientRequest.java
+++ b/auth-service/src/main/java/shop/genieus/auth/presentation/rest/dto/request/AuthClientRequest.java
@@ -1,0 +1,3 @@
+package shop.genieus.auth.presentation.rest.dto.request;
+
+public record AuthClientRequest(String token, String uri, String method) {}

--- a/auth-service/src/main/resources/redis/find-passport-by-user-id.lua
+++ b/auth-service/src/main/resources/redis/find-passport-by-user-id.lua
@@ -1,0 +1,13 @@
+-- 사용자 ID로 세션 ID 조회
+local sessionId = redis.call('GET', KEYS[1])
+
+-- 세션 ID가 없으면 nil 반환
+if not sessionId then
+    return nil
+end
+
+-- 세션 ID로 패스포트 데이터 조회
+local passportJson = redis.call('GET', KEYS[2] .. sessionId)
+
+-- 결과 반환
+return passportJson

--- a/auth-service/src/main/resources/redis/save-passport.lua
+++ b/auth-service/src/main/resources/redis/save-passport.lua
@@ -1,0 +1,7 @@
+-- 패스포트 데이터 저장
+redis.call('SET', KEYS[1], ARGV[1], 'PX', ARGV[2])
+
+-- 사용자 ID와 세션 ID 매핑 정보 저장 (단일 값 사용)
+redis.call('SET', KEYS[2], ARGV[3], 'PX', ARGV[2])
+
+return 1


### PR DESCRIPTION
## 개요
게이트웨이와 인증 서비스 간 통신을 위한 내부 API를 추가하고, 인증된 사용자에게 패스포트를 발급하는 기능을 구현했습니다. 

## 📝 작업 내용
### 변경 사항
- 내부 인증 API 엔드포인트 (`/internal/v1/auth/passport`) 구현
- 패스포트 인코딩 및 발급 서비스 구현
- Redis 기반 패스포트 캐싱
- 패스포트 관리를 위한 Lua 스크립트 추가

### 변경 이유
- 액세스 토큰 검증 후 패스포트를 통한 권한 정보 전달
- 패스포트 캐싱으로 반복적인 인증 요청 최적화
- 마이크로서비스 아키텍처에서의 인증 정보 전파 구현

### 추가 설명
**패스포트 캐싱 정책:**
- Redis에 사용자별 패스포트 캐싱
- 키 구조:
  - `passport:{sessionId}`: 패스포트 데이터 저장
  - `user:passport:{userId}`: 사용자 ID와 세션 ID 매핑
- Lua 스크립트를 통한 저장 및 조회 작업

**패스포트 발급 흐름:**

![image](https://github.com/user-attachments/assets/0affdba2-8e21-46c7-9c97-1b6f382e8813)


1. API 게이트웨이가 내부 API 컨트롤러에 패스포트 발급 요청(액세스 토큰 포함)
2. 컨트롤러가 인증 서비스에게 액세스 토큰 검증 요청
3. 인증 서비스가 토큰 검증 후 결과 반환
4. 검증 결과를 바탕으로 패스포트 서비스에 패스포트 발급 요청
5. Redis 캐시에서 기존 패스포트 확인
 a. 캐시에 있으면 반환
 b. 없으면 사용자 정보 조회 후 새 패스포트 생성 및 저장
6. 패스포트 인코딩 및 응답 반환
7. 게이트웨이는 패스포트를 이용해 권한 확인 후 요청 라우팅

## 💬리뷰 요구사항

#### #️⃣ 연관된 이슈
closed #19

## PR 유형
이 PR은 어떤 변경 사항을 포함하고 있나요?
- [x] 새로운 기능 추가

## ✅ Check List
PR이 다음 요구 사항을 충족하는지 확인하세요.
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다. (버그 수정/기능에 대한 테스트)
- [ ] CI/CD 파이프라인을 통과했습니다.