### PR TITLE
[Feat] 주문 서비스 카프카 - 집킨 연동 및 공통모듈 1.5.0 

### DIFF
--- a/order-service/build.gradle
+++ b/order-service/build.gradle
@@ -37,7 +37,7 @@ ext {
 
 dependencies {
     //common-lib
-    implementation 'com.genieus:genieus-common-lib:1.3.1'
+    implementation 'com.genieus:genieus-common-lib:1.5.0'
 
     // lombok
     compileOnly 'org.projectlombok:lombok'
@@ -63,7 +63,7 @@ dependencies {
     implementation 'org.springframework.cloud:spring-cloud-starter-config'
     implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
     implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
-    
+
     // resilience4j
     implementation 'org.springframework.cloud:spring-cloud-starter-circuitbreaker-resilience4j'
 

--- a/order-service/src/main/java/shop/genieus/order/global/config/KafkaConsumerConfig.java
+++ b/order-service/src/main/java/shop/genieus/order/global/config/KafkaConsumerConfig.java
@@ -14,7 +14,6 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.kafka.annotation.EnableKafka;
 import org.springframework.kafka.core.ConsumerFactory;
 import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
-import org.springframework.kafka.support.serializer.JsonDeserializer;
 
 @EnableKafka
 @Configuration
@@ -32,10 +31,7 @@ public class KafkaConsumerConfig {
     props.put(BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
     props.put(GROUP_ID_CONFIG, groupId);
     props.put(KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
-    props.put(VALUE_DESERIALIZER_CLASS_CONFIG, JsonDeserializer.class);
-    props.put(
-        JsonDeserializer.TRUSTED_PACKAGES,
-        "com.genieus.common.event,shop.genieus.order.domain.event");
+    props.put(VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
     return props;
   }
 

--- a/order-service/src/main/java/shop/genieus/order/infrastructure/event/producer/OrderKafkaProducer.java
+++ b/order-service/src/main/java/shop/genieus/order/infrastructure/event/producer/OrderKafkaProducer.java
@@ -2,9 +2,14 @@ package shop.genieus.order.infrastructure.event.producer;
 
 import com.genieus.common.event.DomainEvent;
 import com.genieus.common.event.EventEnvelope;
+import io.micrometer.tracing.Span;
+import io.micrometer.tracing.TraceContext;
+import io.micrometer.tracing.Tracer;
 import java.util.concurrent.CompletableFuture;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.header.internals.RecordHeader;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.kafka.support.SendResult;
@@ -16,32 +21,48 @@ import org.springframework.stereotype.Component;
 public class OrderKafkaProducer {
 
   private final KafkaTemplate<String, EventEnvelope<? extends DomainEvent>> kafkaTemplate;
+  private final Tracer tracer;
 
   @Value("${spring.kafka.template.default-topic}")
   private String orderTopic;
 
   public void publish(String key, EventEnvelope<? extends DomainEvent> eventEnvelop) {
-    CompletableFuture<SendResult<String, EventEnvelope<? extends DomainEvent>>> result =
-        kafkaTemplate.send(orderTopic, key, eventEnvelop);
-    log.info("[publish] key: {}, eventType: {}", key, eventEnvelop.getEventType());
+    Span span =
+        tracer
+            .nextSpan()
+            .name("kafka.produce")
+            .tag("eventType", eventEnvelop.getEventType())
+            .start();
 
-    result.whenComplete(
-        (sendResult, exception) -> {
-          if (exception != null) {
-            log.error(
-                "[publish] 메시지 전송 실패: key={}, eventType={}, error={}",
-                key,
-                eventEnvelop.getEventType(),
-                exception.getMessage());
-            // TODO: 에러 핸들링 전략 구현 (재시도, DLQ 등)
-          } else {
-            log.debug(
-                "[publish] 메시지 전송 성공: key={}, topic={}, partition={}, offset={}",
-                key,
-                sendResult.getRecordMetadata().topic(),
-                sendResult.getRecordMetadata().partition(),
-                sendResult.getRecordMetadata().offset());
-          }
-        });
+    try (Tracer.SpanInScope scope = tracer.withSpan(span)) {
+      TraceContext context = span.context();
+      ProducerRecord<String, EventEnvelope<? extends DomainEvent>> record =
+          new ProducerRecord<>(orderTopic, key, eventEnvelop);
+
+      record.headers().add(new RecordHeader("traceId", context.traceId().getBytes()));
+      record.headers().add(new RecordHeader("spanId", context.spanId().getBytes()));
+      if (context.parentId() != null) {
+        record.headers().add(new RecordHeader("parentId", context.parentId().getBytes()));
+      }
+
+      CompletableFuture<SendResult<String, EventEnvelope<? extends DomainEvent>>> result =
+          kafkaTemplate.send(record);
+
+      result.whenComplete(
+          (sendResult, exception) -> {
+            if (exception != null) {
+              log.error("[publish] Kafka 전송 실패: {}", exception.getMessage());
+              // TODO: 에러 핸들링 전략 구현 (재시도, DLQ 등)
+            } else {
+              log.debug(
+                  "[publish] Kafka 전송 성공: offset={}", sendResult.getRecordMetadata().offset());
+            }
+            span.end();
+          });
+    } catch (Exception e) {
+      span.error(e);
+      span.end();
+      throw e;
+    }
   }
 }

--- a/order-service/src/main/java/shop/genieus/order/infrastructure/event/producer/OrderKafkaProducer.java
+++ b/order-service/src/main/java/shop/genieus/order/infrastructure/event/producer/OrderKafkaProducer.java
@@ -5,6 +5,7 @@ import com.genieus.common.event.EventEnvelope;
 import io.micrometer.tracing.Span;
 import io.micrometer.tracing.TraceContext;
 import io.micrometer.tracing.Tracer;
+import java.nio.charset.StandardCharsets;
 import java.util.concurrent.CompletableFuture;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -39,10 +40,16 @@ public class OrderKafkaProducer {
       ProducerRecord<String, EventEnvelope<? extends DomainEvent>> record =
           new ProducerRecord<>(orderTopic, key, eventEnvelop);
 
-      record.headers().add(new RecordHeader("traceId", context.traceId().getBytes()));
-      record.headers().add(new RecordHeader("spanId", context.spanId().getBytes()));
+      record
+          .headers()
+          .add(new RecordHeader("traceId", context.traceId().getBytes(StandardCharsets.UTF_8)));
+      record
+          .headers()
+          .add(new RecordHeader("spanId", context.spanId().getBytes(StandardCharsets.UTF_8)));
       if (context.parentId() != null) {
-        record.headers().add(new RecordHeader("parentId", context.parentId().getBytes()));
+        record
+            .headers()
+            .add(new RecordHeader("parentId", context.parentId().getBytes(StandardCharsets.UTF_8)));
       }
 
       CompletableFuture<SendResult<String, EventEnvelope<? extends DomainEvent>>> result =

--- a/order-service/src/main/java/shop/genieus/order/presentation/event/consumer/OrderKafkaConsumer.java
+++ b/order-service/src/main/java/shop/genieus/order/presentation/event/consumer/OrderKafkaConsumer.java
@@ -1,83 +1,49 @@
 package shop.genieus.order.presentation.event.consumer;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JavaType;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.genieus.common.event.DomainEvent;
-import com.genieus.common.event.EventEnvelope;
-import java.util.Optional;
+import static io.micrometer.tracing.Tracer.*;
+
+import com.genieus.common.event.util.EventRouter;
+import io.micrometer.tracing.Span;
+import io.micrometer.tracing.TraceContext;
+import io.micrometer.tracing.Tracer;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.KafkaHeaders;
+import org.springframework.messaging.handler.annotation.Header;
+import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.stereotype.Component;
-import shop.genieus.order.presentation.event.handler.OrderKafkaEventHandler;
 
 @Slf4j
 @Component
 @RequiredArgsConstructor
 public class OrderKafkaConsumer {
-  private final ObjectMapper objectMapper;
-  private final OrderKafkaEventHandler orderEventHandler;
+  private static final String SPAN_NAME = "kafka.consume";
 
-  @KafkaListener(topics = "${spring.kafka.consumer.topic.payment}")
-  public void consumePayment(String message) {
-    try {
-      String eventType = extractEventType(message);
-      Class<? extends DomainEvent> eventClass = orderEventHandler.resolve(eventType);
-      if (eventClass == null) {
-        log.info("[consumePayment] 처리 대상이 아닌 이벤트 타입입니다: {}", eventType);
-        return;
-      }
-      EventEnvelope<? extends DomainEvent> envelope = deserializeEnvelope(message, eventClass);
-      DomainEvent event = envelope.getEvent();
-      orderEventHandler.handle(event);
-      log.info(
-          "[consumePayment] 결제 이벤트 처리완료 - 타입: {}, 이벤트: {}",
-          event.getClass().getSimpleName(),
-          event);
+  private final Tracer tracer;
+  private final EventRouter eventRouter;
 
-    } catch (Exception e) {
-      log.error("[consumePayment] 이벤트 처리 실패", e);
+  @KafkaListener(
+      topics = {"${spring.kafka.consumer.topic.payment}", "${spring.kafka.consumer.topic.order}"})
+  public void consume(
+      @Payload String payload,
+      @Header(KafkaHeaders.RECEIVED_TOPIC) String topic,
+      @Header(value = "traceId", required = false) String traceId,
+      @Header(value = "spanId", required = false) String spanId) {
+    Span consumerSpan = createConsumerSpan(traceId, spanId);
+    try (SpanInScope scope = tracer.withSpan(consumerSpan)) {
+      eventRouter.route(topic, payload);
+    } finally {
+      consumerSpan.end();
     }
   }
 
-  @KafkaListener(topics = "${spring.kafka.consumer.topic.order}")
-  public void consumeOrder(String message) {
-    try {
-      String eventType = extractEventType(message);
-      Class<? extends DomainEvent> eventClass = orderEventHandler.resolve(eventType);
-      if (eventClass == null) {
-        log.info("[consumeOrder] 처리 대상이 아닌 이벤트 타입입니다: {}", eventType);
-        return;
-      }
-      EventEnvelope<? extends DomainEvent> envelope = deserializeEnvelope(message, eventClass);
-      orderEventHandler.handle(envelope.getEvent());
-      log.info("[consumeOrder] 주문 이벤트 처리완료: {}", envelope);
-    } catch (Exception e) {
-      log.error("[consumeOrder] 이벤트 처리 실패", e);
+  private Span createConsumerSpan(String traceId, String spanId) {
+    if (traceId == null || spanId == null) {
+      return tracer.nextSpan().name(SPAN_NAME).start();
     }
-  }
-
-  private String extractEventType(String message) {
-    try {
-      JsonNode root = objectMapper.readTree(message);
-      return Optional.ofNullable(root.get("eventType"))
-          .map(JsonNode::asText)
-          .orElseThrow(() -> new IllegalArgumentException("이벤트 메시지에 'eventType' 필드가 존재하지 않습니다."));
-    } catch (JsonProcessingException e) {
-      throw new IllegalArgumentException("이벤트 메시지의 JSON 형식이 잘못되었습니다.");
-    }
-  }
-
-  private EventEnvelope<? extends DomainEvent> deserializeEnvelope(
-      String message, Class<? extends DomainEvent> eventClass) {
-    try {
-      JavaType envelopeType =
-          objectMapper.getTypeFactory().constructParametricType(EventEnvelope.class, eventClass);
-      return objectMapper.readValue(message, envelopeType);
-    } catch (JsonProcessingException e) {
-      throw new IllegalArgumentException("이벤트 메시지를 EventEnvelope로 역직렬화하는 데 실패했습니다.");
-    }
+    TraceContext parentContext =
+        tracer.traceContextBuilder().traceId(traceId).spanId(spanId).sampled(true).build();
+    return tracer.spanBuilder().name(SPAN_NAME).setParent(parentContext).start();
   }
 }

--- a/order-service/src/main/java/shop/genieus/order/presentation/event/consumer/OrderKafkaConsumer.java
+++ b/order-service/src/main/java/shop/genieus/order/presentation/event/consumer/OrderKafkaConsumer.java
@@ -33,6 +33,8 @@ public class OrderKafkaConsumer {
     Span consumerSpan = createConsumerSpan(traceId, spanId);
     try (SpanInScope scope = tracer.withSpan(consumerSpan)) {
       eventRouter.route(topic, payload);
+    } catch (Exception e) {
+      log.error("이벤트 라우팅 중 오류 발생: topic={}, error={}", topic, e.getMessage());
     } finally {
       consumerSpan.end();
     }

--- a/order-service/src/main/java/shop/genieus/order/presentation/event/handler/OrderKafkaEventHandler.java
+++ b/order-service/src/main/java/shop/genieus/order/presentation/event/handler/OrderKafkaEventHandler.java
@@ -31,7 +31,7 @@ public class OrderKafkaEventHandler {
 
   @EventTypeMapping(topic = "payment-events")
   public void handlePaymentCompleted(PaymentCompletedEvent event) {
-    log.info("[handlePayment] 결제 완료 이벤트 수신: {}", event);
+    log.info("[handlePaymentCompleted] 결제 완료 이벤트 수신: {}", event);
     CompleteOrderCommand command = new CompleteOrderCommand(event.orderId());
     orderCommandService.completeOrder(command);
   }

--- a/order-service/src/main/java/shop/genieus/order/presentation/event/handler/OrderKafkaEventHandler.java
+++ b/order-service/src/main/java/shop/genieus/order/presentation/event/handler/OrderKafkaEventHandler.java
@@ -1,15 +1,14 @@
 package shop.genieus.order.presentation.event.handler;
 
-import com.genieus.common.event.DomainEvent;
+import com.genieus.common.event.annotation.EventTypeMapping;
+import com.genieus.common.event.order.OrderCancelTriggerEvent;
 import com.genieus.common.event.payment.PaymentCompletedEvent;
-import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import shop.genieus.order.application.in.command.OrderCommandService;
 import shop.genieus.order.application.in.command.dto.CancelOrderCommand;
 import shop.genieus.order.application.in.command.dto.CompleteOrderCommand;
-import shop.genieus.order.domain.event.OrderCancelTriggerEvent;
 import shop.genieus.order.domain.event.OrderCreatedEvent;
 
 @Slf4j
@@ -18,41 +17,22 @@ import shop.genieus.order.domain.event.OrderCreatedEvent;
 public class OrderKafkaEventHandler {
   private final OrderCommandService orderCommandService;
 
-  private final Map<String, Class<? extends DomainEvent>> eventTypeMap =
-      Map.of(
-          "com.genieus.common.event.payment.PaymentCompletedEvent",
-          PaymentCompletedEvent.class,
-          "shop.genieus.order.domain.event.OrderCreatedEvent",
-          OrderCreatedEvent.class,
-          "shop.genieus.order.domain.event.OrderCancelTriggerEvent",
-          OrderCancelTriggerEvent.class);
-
-  public Class<? extends DomainEvent> resolve(String eventType) {
-    Class<? extends DomainEvent> eventClass = eventTypeMap.get(eventType);
-    if (eventClass == null) {
-      log.warn("[resolve] 알 수 없는 이벤트 타입: {}", eventType);
-    }
-    return eventClass;
+  @EventTypeMapping(topic = "order-events")
+  public void handleOrderCreated(OrderCreatedEvent event) {
+    log.info("[handleOrderCreated] 주문 생성 이벤트 수신 : {}", event);
   }
 
-  public void handle(DomainEvent domainEvent) {
-    if (domainEvent instanceof PaymentCompletedEvent event) {
-      log.info("[handle] 결제 완료 이벤트 수신: {}", event);
-      CompleteOrderCommand command = new CompleteOrderCommand(event.orderId());
-      orderCommandService.completeOrder(command);
-      return;
-    }
-    if (domainEvent instanceof OrderCreatedEvent event) {
-      log.info("[handle] 주문 생성 이벤트 수신: {}", event);
-      // todo 조회모델 생성
-      return;
-    }
-    if (domainEvent instanceof OrderCancelTriggerEvent event) {
-      log.info("[handle] 주문 취소 트리거 이벤트 수신: {}", event);
-      CancelOrderCommand command = new CancelOrderCommand(-1L, event.orderId());
-      orderCommandService.cancelOrderBySystem(command);
-      return;
-    }
-    log.warn("[OrderKafkaEventHandler] 처리할 수 없는 이벤트 타입입니다: {}", domainEvent.getClass().getName());
+  @EventTypeMapping(topic = "order-events")
+  public void handleOrderCancelTrigger(OrderCancelTriggerEvent event) {
+    log.info("[handleOrderCancelTrigger] 주문 취소 트리거 이벤트 수신 : {}", event);
+    CancelOrderCommand command = new CancelOrderCommand(-1L, event.orderId());
+    orderCommandService.cancelOrderBySystem(command);
+  }
+
+  @EventTypeMapping(topic = "payment-events")
+  public void handlePaymentCompleted(PaymentCompletedEvent event) {
+    log.info("[handlePayment] 결제 완료 이벤트 수신: {}", event);
+    CompleteOrderCommand command = new CompleteOrderCommand(event.orderId());
+    orderCommandService.completeOrder(command);
   }
 }

--- a/order-service/src/main/resources/application-local.yml
+++ b/order-service/src/main/resources/application-local.yml
@@ -19,13 +19,12 @@ spring:
   kafka:
     bootstrap-servers: localhost:19092,localhost:19093
     template:
-      default-topic: order
+      default-topic: order-events
     consumer:
       group-id: order-service
       topic:
-        payment: payment
-        order: order
-
+        payment: payment-events
+        order: order-events
 logging:
   level:
     root: info
@@ -33,6 +32,7 @@ logging:
     org.springframework.cloud.gateway: debug
     org.springframework.web.reactive: info
     reactor.netty: warn
+    org.apache.kafka.clients.Metadata: warn
 
 management:
   zipkin:


### PR DESCRIPTION
## 개요
<!-- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 무엇을 수정했는지, 왜 수정했는지 간략하게 설명 -->
- 카프카 - 집킨 연동
- 공통모듈 1.5.0 
- 카프카 -이벤트 전체적인 수정
## 📝 작업 내용
### 변경 사항

### 변경 이유

## PR 유형

이 PR은 어떤 변경 사항을 포함하고 있나요?

- [X] 새로운 기능 추가

## ✅ Check List

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [X] 커밋 메시지 컨벤션에 맞게 작성했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - Kafka 메시지의 분산 추적(Distributed Tracing) 기능이 추가되어 추적 정보를 메시지 헤더에 포함하고, 이벤트 소비 시 추적 컨텍스트를 연계합니다.

- **리팩터링**
  - Kafka 이벤트 수신 및 처리 구조가 단일 메서드와 어노테이션 기반 라우팅으로 단순화되었습니다.
  - 이벤트 핸들러가 이벤트별 전용 메서드로 분리되어 코드 가독성이 향상되었습니다.

- **설정 변경**
  - Kafka 토픽 이름이 "order", "payment"에서 "order-events", "payment-events"로 변경되었습니다.
  - Kafka 로그 레벨이 warn으로 조정되었습니다.

- **버그 수정**
  - Kafka 메시지 값 역직렬화 방식이 JSON에서 문자열로 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->